### PR TITLE
feat(buildpacks): support Node 24 PnP ESM runtime

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -51,7 +51,7 @@ const RAW_RUNTIME_STATE =
           ["@jest/core", "virtual:7618f6ad4e0388e74cf2ca367fb81bdd928500796eac7e9c98a77538e257ec4f2b1a0a630357b583838239427f6b3131254ff1bd642d5e66b19563fff192599d#npm:29.7.0"],\
           ["@types/eslint", "npm:8.56.7"],\
           ["@types/jest", "npm:29.5.12"],\
-          ["@types/node", "npm:24.12.3"],\
+          ["@types/node", "npm:20.12.3"],\
           ["eslint", "npm:8.57.0"],\
           ["typescript", "patch:typescript@npm%3A5.2.2#optional!builtin<compat/typescript>::version=5.2.2&hash=f3b441"]\
         ],\
@@ -263,7 +263,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@atls/buildpack-yarn-cache", "workspace:buildpacks/yarn-cache"],\
           ["@atls/libcnb", "workspace:libcnb/libcnb"],\
-          ["@types/node", "npm:24.12.3"],\
+          ["@types/node", "npm:20.12.3"],\
           ["@yarnpkg/core", "npm:4.0.3"],\
           ["@yarnpkg/fslib", "npm:3.0.2"],\
           ["execa", "npm:5.1.1"],\
@@ -279,7 +279,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@atls/buildpack-yarn-install", "workspace:buildpacks/yarn-install"],\
           ["@atls/libcnb", "workspace:libcnb/libcnb"],\
-          ["@types/node", "npm:24.12.3"],\
+          ["@types/node", "npm:20.12.3"],\
           ["@yarnpkg/core", "npm:4.0.3"],\
           ["@yarnpkg/fslib", "npm:3.0.2"],\
           ["execa", "npm:5.1.1"]\
@@ -293,7 +293,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@atls/buildpack-yarn-workspace-start", "workspace:buildpacks/yarn-workspace-start"],\
           ["@atls/libcnb", "workspace:libcnb/libcnb"],\
-          ["@types/node", "npm:24.12.3"],\
+          ["@types/node", "npm:20.12.3"],\
           ["@yarnpkg/core", "npm:4.0.3"],\
           ["@yarnpkg/fslib", "npm:3.0.2"],\
           ["execa", "npm:5.1.1"]\
@@ -369,7 +369,7 @@ const RAW_RUNTIME_STATE =
           ["@babel/types", "npm:7.24.0"],\
           ["@iarna/toml", "npm:2.2.5"],\
           ["@types/execa", "npm:2.0.0"],\
-          ["@types/node", "npm:24.12.3"],\
+          ["@types/node", "npm:20.12.3"],\
           ["execa", "npm:5.1.1"]\
         ],\
         "linkType": "SOFT"\
@@ -2305,14 +2305,6 @@ const RAW_RUNTIME_STATE =
           ["undici-types", "npm:5.26.5"]\
         ],\
         "linkType": "HARD"\
-      }],\
-      ["npm:24.12.3", {\
-        "packageLocation": "../.yarn/berry/cache/@types-node-npm-24.12.3-5cb92d2dfa-10.zip/node_modules/@types/node/",\
-        "packageDependencies": [\
-          ["@types/node", "npm:24.12.3"],\
-          ["undici-types", "npm:7.16.0"]\
-        ],\
-        "linkType": "HARD"\
       }]\
     ]],\
     ["@types/responselike", [\
@@ -4064,7 +4056,7 @@ const RAW_RUNTIME_STATE =
           ["@jest/core", "virtual:7618f6ad4e0388e74cf2ca367fb81bdd928500796eac7e9c98a77538e257ec4f2b1a0a630357b583838239427f6b3131254ff1bd642d5e66b19563fff192599d#npm:29.7.0"],\
           ["@types/eslint", "npm:8.56.7"],\
           ["@types/jest", "npm:29.5.12"],\
-          ["@types/node", "npm:24.12.3"],\
+          ["@types/node", "npm:20.12.3"],\
           ["eslint", "npm:8.57.0"],\
           ["typescript", "patch:typescript@npm%3A5.2.2#optional!builtin<compat/typescript>::version=5.2.2&hash=f3b441"]\
         ],\
@@ -8640,13 +8632,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/undici-types-npm-5.26.5-de4f7c7bb9-10.zip/node_modules/undici-types/",\
         "packageDependencies": [\
           ["undici-types", "npm:5.26.5"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:7.16.0", {\
-        "packageLocation": "../.yarn/berry/cache/undici-types-npm-7.16.0-0e23b08124-10.zip/node_modules/undici-types/",\
-        "packageDependencies": [\
-          ["undici-types", "npm:7.16.0"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -51,7 +51,7 @@ const RAW_RUNTIME_STATE =
           ["@jest/core", "virtual:7618f6ad4e0388e74cf2ca367fb81bdd928500796eac7e9c98a77538e257ec4f2b1a0a630357b583838239427f6b3131254ff1bd642d5e66b19563fff192599d#npm:29.7.0"],\
           ["@types/eslint", "npm:8.56.7"],\
           ["@types/jest", "npm:29.5.12"],\
-          ["@types/node", "npm:20.12.3"],\
+          ["@types/node", "npm:24.12.3"],\
           ["eslint", "npm:8.57.0"],\
           ["typescript", "patch:typescript@npm%3A5.2.2#optional!builtin<compat/typescript>::version=5.2.2&hash=f3b441"]\
         ],\
@@ -263,7 +263,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@atls/buildpack-yarn-cache", "workspace:buildpacks/yarn-cache"],\
           ["@atls/libcnb", "workspace:libcnb/libcnb"],\
-          ["@types/node", "npm:20.12.3"],\
+          ["@types/node", "npm:24.12.3"],\
           ["@yarnpkg/core", "npm:4.0.3"],\
           ["@yarnpkg/fslib", "npm:3.0.2"],\
           ["execa", "npm:5.1.1"],\
@@ -279,7 +279,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@atls/buildpack-yarn-install", "workspace:buildpacks/yarn-install"],\
           ["@atls/libcnb", "workspace:libcnb/libcnb"],\
-          ["@types/node", "npm:20.12.3"],\
+          ["@types/node", "npm:24.12.3"],\
           ["@yarnpkg/core", "npm:4.0.3"],\
           ["@yarnpkg/fslib", "npm:3.0.2"],\
           ["execa", "npm:5.1.1"]\
@@ -293,7 +293,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@atls/buildpack-yarn-workspace-start", "workspace:buildpacks/yarn-workspace-start"],\
           ["@atls/libcnb", "workspace:libcnb/libcnb"],\
-          ["@types/node", "npm:20.12.3"],\
+          ["@types/node", "npm:24.12.3"],\
           ["@yarnpkg/core", "npm:4.0.3"],\
           ["@yarnpkg/fslib", "npm:3.0.2"],\
           ["execa", "npm:5.1.1"]\
@@ -369,7 +369,7 @@ const RAW_RUNTIME_STATE =
           ["@babel/types", "npm:7.24.0"],\
           ["@iarna/toml", "npm:2.2.5"],\
           ["@types/execa", "npm:2.0.0"],\
-          ["@types/node", "npm:20.12.3"],\
+          ["@types/node", "npm:24.12.3"],\
           ["execa", "npm:5.1.1"]\
         ],\
         "linkType": "SOFT"\
@@ -2305,6 +2305,14 @@ const RAW_RUNTIME_STATE =
           ["undici-types", "npm:5.26.5"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:24.12.3", {\
+        "packageLocation": "../.yarn/berry/cache/@types-node-npm-24.12.3-5cb92d2dfa-10.zip/node_modules/@types/node/",\
+        "packageDependencies": [\
+          ["@types/node", "npm:24.12.3"],\
+          ["undici-types", "npm:7.16.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["@types/responselike", [\
@@ -4056,7 +4064,7 @@ const RAW_RUNTIME_STATE =
           ["@jest/core", "virtual:7618f6ad4e0388e74cf2ca367fb81bdd928500796eac7e9c98a77538e257ec4f2b1a0a630357b583838239427f6b3131254ff1bd642d5e66b19563fff192599d#npm:29.7.0"],\
           ["@types/eslint", "npm:8.56.7"],\
           ["@types/jest", "npm:29.5.12"],\
-          ["@types/node", "npm:20.12.3"],\
+          ["@types/node", "npm:24.12.3"],\
           ["eslint", "npm:8.57.0"],\
           ["typescript", "patch:typescript@npm%3A5.2.2#optional!builtin<compat/typescript>::version=5.2.2&hash=f3b441"]\
         ],\
@@ -8632,6 +8640,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/undici-types-npm-5.26.5-de4f7c7bb9-10.zip/node_modules/undici-types/",\
         "packageDependencies": [\
           ["undici-types", "npm:5.26.5"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:7.16.0", {\
+        "packageLocation": "../.yarn/berry/cache/undici-types-npm-7.16.0-0e23b08124-10.zip/node_modules/undici-types/",\
+        "packageDependencies": [\
+          ["undici-types", "npm:7.16.0"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 ## Порядок обновления версии `NodeJS` базового билдера
 
+Текущий production baseline: `Node.js 24 LTS`.
+
 Для всех операций необходим аккаунт Docker с доступом к `atlantislab`.
 
-1. `/stacks/node/.../Dockerfile` - поправить версию ноды на необходимую
+1. `/stacks/node/.../Dockerfile` - поправить версию ноды на актуальную LTS
 2. `/stacks/build.sh`
 3. Проверяем версию ноды через `docker inspect X` где Х - ID созданного образа
 4. `/stacks/push.sh`
@@ -15,10 +17,20 @@
 
 Делаем билдер:
 
-1. Запустить контейнер `atlantis/stacknode:run`
-2. Запустить контейнер `atlantis/stacknode:build`
-3. `/builders/build:sh` - поправить тег на `:buster-XX.XX`, подставив версию ноды до минорной. ВАЖНО: тег всегда меняем кроме случаев когда идет исправление созданного образа. Добавляя новый тег вы создаете новый образ под новым тегом вместе перезаписывания старого.
+1. Собрать или подтянуть `atlantislab/stack-node:run`
+2. Собрать или подтянуть `atlantislab/stack-node:build`
+3. `/builders/build.sh` и `/builders/build-local.sh` - поправить тег билдера на актуальную major-версию Node. ВАЖНО: тег всегда меняем кроме случаев когда идет исправление созданного образа. Добавляя новый тег вы создаете новый образ под новым тегом вместе перезаписывания старого.
 4. `/builders/build.sh`
 5. Проверяем версию ноды через `docker inspect X` где Х - ID созданного образа
-6. `docker image push atlantislab/builder-base:buster-XX.XX`
+6. `docker image push atlantislab/builder-base:24`
 7. Проверяем в [Docker Hub](https://hub.docker.com/r/atlantislab/builder-base/tags) - должен появится ваш образ
+
+## Runtime запуск Yarn PnP ESM workspace
+
+`buildpack-yarn-workspace-start` формирует launch layer с `NODE_OPTIONS` для workspace без `node_modules`.
+
+Если в приложении есть `.pnp.cjs`, buildpack добавляет его через `--require`.
+Если в приложении есть `.pnp.loader.mjs`, buildpack добавляет его через `--loader`.
+Source maps включаются через `--enable-source-maps`.
+
+Прикладной `package.json` не должен дублировать эти флаги в `start`-команде. Для ESM workspace достаточно запускать собранную точку входа, например `node dist/index.js`.

--- a/builders/build-local.sh
+++ b/builders/build-local.sh
@@ -2,5 +2,6 @@
 set -e
 
 BUILDER_DIR="${1:-base}"
+DIR=$(cd "$(dirname "$0")" && pwd)
 
-pack builder create "atlantislab/builder-${BUILDER_DIR}:22" pull-policy=never --verbose --config "./${BUILDER_DIR}/builder.toml"
+pack builder create "atlantislab/builder-${BUILDER_DIR}:24" --pull-policy never --verbose --config "${DIR}/${BUILDER_DIR}/builder.toml"

--- a/builders/build.sh
+++ b/builders/build.sh
@@ -2,5 +2,6 @@
 set -e
 
 BUILDER_DIR="${1:-base}"
+DIR=$(cd "$(dirname "$0")" && pwd)
 
-pack builder create "atlantislab/builder-${BUILDER_DIR}:22" --verbose --config "./${BUILDER_DIR}/builder.toml" --publish
+pack builder create "atlantislab/builder-${BUILDER_DIR}:24" --verbose --config "${DIR}/${BUILDER_DIR}/builder.toml" --publish

--- a/buildpacks/yarn-cache/package.json
+++ b/buildpacks/yarn-cache/package.json
@@ -21,6 +21,6 @@
     "yaml": "1.10.2"
   },
   "devDependencies": {
-    "@types/node": "20"
+    "@types/node": "24"
   }
 }

--- a/buildpacks/yarn-cache/package.json
+++ b/buildpacks/yarn-cache/package.json
@@ -21,6 +21,6 @@
     "yaml": "1.10.2"
   },
   "devDependencies": {
-    "@types/node": "24"
+    "@types/node": "20.12.3"
   }
 }

--- a/buildpacks/yarn-cache/src/yarn-cache.builder.ts
+++ b/buildpacks/yarn-cache/src/yarn-cache.builder.ts
@@ -34,7 +34,7 @@ export class YarnCacheBuilder implements Builder {
       cacheLayer.setMetadata('locksum', yarnLockCheckSum.toString())
     }
 
-    await xfs.rmdirPromise(yarnCachePath, { recursive: true })
+    await xfs.removePromise(yarnCachePath)
 
     const yarnrc = await xfs.readFilePromise(
       ppath.join(applicationDir, '.yarnrc.yml' as PortablePath)

--- a/buildpacks/yarn-install/package.json
+++ b/buildpacks/yarn-install/package.json
@@ -19,6 +19,6 @@
     "execa": "5.1.1"
   },
   "devDependencies": {
-    "@types/node": "24"
+    "@types/node": "20.12.3"
   }
 }

--- a/buildpacks/yarn-install/package.json
+++ b/buildpacks/yarn-install/package.json
@@ -19,6 +19,6 @@
     "execa": "5.1.1"
   },
   "devDependencies": {
-    "@types/node": "20"
+    "@types/node": "24"
   }
 }

--- a/buildpacks/yarn-workspace-start/package.json
+++ b/buildpacks/yarn-workspace-start/package.json
@@ -19,6 +19,6 @@
     "execa": "5.1.1"
   },
   "devDependencies": {
-    "@types/node": "24"
+    "@types/node": "20.12.3"
   }
 }

--- a/buildpacks/yarn-workspace-start/package.json
+++ b/buildpacks/yarn-workspace-start/package.json
@@ -19,6 +19,6 @@
     "execa": "5.1.1"
   },
   "devDependencies": {
-    "@types/node": "20"
+    "@types/node": "24"
   }
 }

--- a/buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.ts
+++ b/buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.ts
@@ -9,30 +9,32 @@ import { BuildContext } from '@atls/libcnb'
 import { BuildResult }  from '@atls/libcnb'
 import { Process }      from '@atls/libcnb'
 
+const RUN_SCRIPT_PATH = '/workspace/run.sh'
+const PNP_CJS = '.pnp.cjs'
+const PNP_ESM_LOADER = '.pnp.loader.mjs'
+
 export class YarnWorkspaceStartBuilder implements Builder {
   async build(ctx: BuildContext): Promise<BuildResult> {
     const pkgjson = JSON.parse(readFileSync(join(ctx.applicationDir, 'package.json'), 'utf-8'))
 
     const command = pkgjson.scripts.start
 
-    await writeFile('/workspace/run.sh', `#!/usr/bin/env bash\numask 0002\n${command}`)
-    await chmod('/workspace/run.sh', '755')
+    await writeFile(RUN_SCRIPT_PATH, `#!/usr/bin/env bash\numask 0002\n${command}`)
+    await chmod(RUN_SCRIPT_PATH, '755')
 
     const nodeOptionsLayer = await ctx.layers.get('node-options', true, true, true)
 
-    const nodeOptions: Array<string> = []
+    const nodeOptions: Array<string> = ['--enable-source-maps']
 
     try {
-      await access(join(ctx.applicationDir, '.pnp.cjs'))
-      nodeOptions.push('--require', join(ctx.applicationDir, '.pnp.cjs'))
+      await access(join(ctx.applicationDir, PNP_CJS))
+      nodeOptions.push('--require', join(ctx.applicationDir, PNP_CJS))
     } catch {}
 
     try {
-      await access(join(ctx.applicationDir, '.pnp.loader.mjs'))
-      nodeOptions.push('--import', join(ctx.applicationDir, '.pnp.loader.mjs'))
+      await access(join(ctx.applicationDir, PNP_ESM_LOADER))
+      nodeOptions.push('--loader', join(ctx.applicationDir, PNP_ESM_LOADER))
     } catch {}
-
-    console.debug('NODE_OPTIONS', nodeOptions)
 
     nodeOptionsLayer.launchEnv.append(
       'NODE_OPTIONS',

--- a/buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.ts
+++ b/buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.ts
@@ -13,6 +13,16 @@ const RUN_SCRIPT_PATH = '/workspace/run.sh'
 const PNP_CJS = '.pnp.cjs'
 const PNP_ESM_LOADER = '.pnp.loader.mjs'
 
+const fileExists = async (path: string): Promise<boolean> => {
+  try {
+    await access(path)
+
+    return true
+  } catch {
+    return false
+  }
+}
+
 export class YarnWorkspaceStartBuilder implements Builder {
   async build(ctx: BuildContext): Promise<BuildResult> {
     const pkgjson = JSON.parse(readFileSync(join(ctx.applicationDir, 'package.json'), 'utf-8'))
@@ -26,15 +36,13 @@ export class YarnWorkspaceStartBuilder implements Builder {
 
     const nodeOptions: Array<string> = ['--enable-source-maps']
 
-    try {
-      await access(join(ctx.applicationDir, PNP_CJS))
+    if (await fileExists(join(ctx.applicationDir, PNP_CJS))) {
       nodeOptions.push('--require', join(ctx.applicationDir, PNP_CJS))
-    } catch {}
+    }
 
-    try {
-      await access(join(ctx.applicationDir, PNP_ESM_LOADER))
+    if (await fileExists(join(ctx.applicationDir, PNP_ESM_LOADER))) {
       nodeOptions.push('--loader', join(ctx.applicationDir, PNP_ESM_LOADER))
-    } catch {}
+    }
 
     nodeOptionsLayer.launchEnv.append(
       'NODE_OPTIONS',

--- a/libcnb/libcnb/package.json
+++ b/libcnb/libcnb/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@babel/types": "7.24.0",
     "@types/execa": "2.0.0",
-    "@types/node": "24"
+    "@types/node": "20.12.3"
   },
   "publishConfig": {
     "main": "dist/index.js",

--- a/libcnb/libcnb/package.json
+++ b/libcnb/libcnb/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@babel/types": "7.24.0",
     "@types/execa": "2.0.0",
-    "@types/node": "20"
+    "@types/node": "24"
   },
   "publishConfig": {
     "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@jest/core": "29.7.0",
     "@types/eslint": "8",
     "@types/jest": "29",
-    "@types/node": "20",
+    "@types/node": "24",
     "eslint": "8.57.0",
     "typescript": "5.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@jest/core": "29.7.0",
     "@types/eslint": "8",
     "@types/jest": "29",
-    "@types/node": "24",
+    "@types/node": "20.12.3",
     "eslint": "8.57.0",
     "typescript": "5.2.2"
   },

--- a/stacks/node/base/Dockerfile
+++ b/stacks/node/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim
+FROM node:24-slim
 
 ARG cnb_uid=1001
 ARG cnb_gid=1001

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,7 +187,7 @@ __metadata:
   resolution: "@atls/buildpack-yarn-cache@workspace:buildpacks/yarn-cache"
   dependencies:
     "@atls/libcnb": "workspace:0.0.1"
-    "@types/node": "npm:24"
+    "@types/node": "npm:20.12.3"
     "@yarnpkg/core": "npm:4.0.3"
     "@yarnpkg/fslib": "npm:3.0.2"
     execa: "npm:5.1.1"
@@ -201,7 +201,7 @@ __metadata:
   resolution: "@atls/buildpack-yarn-install@workspace:buildpacks/yarn-install"
   dependencies:
     "@atls/libcnb": "workspace:0.0.1"
-    "@types/node": "npm:24"
+    "@types/node": "npm:20.12.3"
     "@yarnpkg/core": "npm:4.0.3"
     "@yarnpkg/fslib": "npm:3.0.2"
     execa: "npm:5.1.1"
@@ -213,7 +213,7 @@ __metadata:
   resolution: "@atls/buildpack-yarn-workspace-start@workspace:buildpacks/yarn-workspace-start"
   dependencies:
     "@atls/libcnb": "workspace:*"
-    "@types/node": "npm:24"
+    "@types/node": "npm:20.12.3"
     "@yarnpkg/core": "npm:4.0.3"
     "@yarnpkg/fslib": "npm:3.0.2"
     execa: "npm:5.1.1"
@@ -281,7 +281,7 @@ __metadata:
     "@babel/types": "npm:7.24.0"
     "@iarna/toml": "npm:2.2.5"
     "@types/execa": "npm:2.0.0"
-    "@types/node": "npm:24"
+    "@types/node": "npm:20.12.3"
     execa: "npm:5.1.1"
   languageName: unknown
   linkType: soft
@@ -1685,21 +1685,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
+"@types/node@npm:*, @types/node@npm:20.12.3":
   version: 20.12.3
   resolution: "@types/node@npm:20.12.3"
   dependencies:
     undici-types: "npm:~5.26.4"
   checksum: 10/3f3c5c6ba118a18aa997c51cdc3c66259d69021f87475a99ed6c913a6956e22de49748e09843bf6447a7a63ae474e61945a6dbcca93e23b2359fc0b6f9914f7a
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:24":
-  version: 24.12.3
-  resolution: "@types/node@npm:24.12.3"
-  dependencies:
-    undici-types: "npm:~7.16.0"
-  checksum: 10/a7441f1505fee5c049b0c64c70707b5081cdeb945537fd9249a4304d636c27213ee9973bfd68cec5e5326e0cab5506d2a45e60d6528882bc8096c6e1195b661a
   languageName: node
   linkType: hard
 
@@ -2884,7 +2875,7 @@ __metadata:
     "@jest/core": "npm:29.7.0"
     "@types/eslint": "npm:8"
     "@types/jest": "npm:29"
-    "@types/node": "npm:24"
+    "@types/node": "npm:20.12.3"
     eslint: "npm:8.57.0"
     typescript: "npm:5.2.2"
   languageName: unknown
@@ -6821,13 +6812,6 @@ __metadata:
   version: 5.26.5
   resolution: "undici-types@npm:5.26.5"
   checksum: 10/0097779d94bc0fd26f0418b3a05472410408877279141ded2bd449167be1aed7ea5b76f756562cb3586a07f251b90799bab22d9019ceba49c037c76445f7cddd
-  languageName: node
-  linkType: hard
-
-"undici-types@npm:~7.16.0":
-  version: 7.16.0
-  resolution: "undici-types@npm:7.16.0"
-  checksum: 10/db43439f69c2d94cc29f75cbfe9de86df87061d6b0c577ebe9bb3255f49b22c50162a7d7eb413b0458b6510b8ca299ac7cff38c3a29fbd31af9f504bcf7fbc0d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,7 +187,7 @@ __metadata:
   resolution: "@atls/buildpack-yarn-cache@workspace:buildpacks/yarn-cache"
   dependencies:
     "@atls/libcnb": "workspace:0.0.1"
-    "@types/node": "npm:20"
+    "@types/node": "npm:24"
     "@yarnpkg/core": "npm:4.0.3"
     "@yarnpkg/fslib": "npm:3.0.2"
     execa: "npm:5.1.1"
@@ -201,7 +201,7 @@ __metadata:
   resolution: "@atls/buildpack-yarn-install@workspace:buildpacks/yarn-install"
   dependencies:
     "@atls/libcnb": "workspace:0.0.1"
-    "@types/node": "npm:20"
+    "@types/node": "npm:24"
     "@yarnpkg/core": "npm:4.0.3"
     "@yarnpkg/fslib": "npm:3.0.2"
     execa: "npm:5.1.1"
@@ -213,7 +213,7 @@ __metadata:
   resolution: "@atls/buildpack-yarn-workspace-start@workspace:buildpacks/yarn-workspace-start"
   dependencies:
     "@atls/libcnb": "workspace:*"
-    "@types/node": "npm:20"
+    "@types/node": "npm:24"
     "@yarnpkg/core": "npm:4.0.3"
     "@yarnpkg/fslib": "npm:3.0.2"
     execa: "npm:5.1.1"
@@ -281,7 +281,7 @@ __metadata:
     "@babel/types": "npm:7.24.0"
     "@iarna/toml": "npm:2.2.5"
     "@types/execa": "npm:2.0.0"
-    "@types/node": "npm:20"
+    "@types/node": "npm:24"
     execa: "npm:5.1.1"
   languageName: unknown
   linkType: soft
@@ -1685,12 +1685,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:20":
+"@types/node@npm:*":
   version: 20.12.3
   resolution: "@types/node@npm:20.12.3"
   dependencies:
     undici-types: "npm:~5.26.4"
   checksum: 10/3f3c5c6ba118a18aa997c51cdc3c66259d69021f87475a99ed6c913a6956e22de49748e09843bf6447a7a63ae474e61945a6dbcca93e23b2359fc0b6f9914f7a
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:24":
+  version: 24.12.3
+  resolution: "@types/node@npm:24.12.3"
+  dependencies:
+    undici-types: "npm:~7.16.0"
+  checksum: 10/a7441f1505fee5c049b0c64c70707b5081cdeb945537fd9249a4304d636c27213ee9973bfd68cec5e5326e0cab5506d2a45e60d6528882bc8096c6e1195b661a
   languageName: node
   linkType: hard
 
@@ -2875,7 +2884,7 @@ __metadata:
     "@jest/core": "npm:29.7.0"
     "@types/eslint": "npm:8"
     "@types/jest": "npm:29"
-    "@types/node": "npm:20"
+    "@types/node": "npm:24"
     eslint: "npm:8.57.0"
     typescript: "npm:5.2.2"
   languageName: unknown
@@ -6812,6 +6821,13 @@ __metadata:
   version: 5.26.5
   resolution: "undici-types@npm:5.26.5"
   checksum: 10/0097779d94bc0fd26f0418b3a05472410408877279141ded2bd449167be1aed7ea5b76f756562cb3586a07f251b90799bab22d9019ceba49c037c76445f7cddd
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.16.0":
+  version: 7.16.0
+  resolution: "undici-types@npm:7.16.0"
+  checksum: 10/db43439f69c2d94cc29f75cbfe9de86df87061d6b0c577ebe9bb3255f49b22c50162a7d7eb413b0458b6510b8ca299ac7cff38c3a29fbd31af9f504bcf7fbc0d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#36

## Как проверять
### Основной сценарий
1. Контекст: buildpack-yarn-workspace на Node 24 LTS, Yarn PnP workspace без node_modules, type: module
Действие: собрать image минимального приложения через pack с локальным buildpack-yarn-workspace и запустить default process
Ожидаемый результат: image стартует без ручных node --require / --loader флагов в package.json, внешняя CJS dependency резолвится через PnP loader

### Дополнительный сценарий
1. Контекст: локальный builder-base для актуального Node baseline
Действие: собрать builder через builders/build-local.sh base
Ожидаемый результат: создаётся atlantislab/builder-base:24, node внутри builder возвращает v24.15.0

## Пруфы
- Локальная сборка workspace
```text
yarn workspaces foreach -Apt run build
Done in 14s 768ms
```
- Локальные checks
```text
yarn lint
Done in 3s 395ms

yarn typecheck
Done in 5s 148ms
```
- Runtime image proof
```text
pack build atls/pnp-cjs-runtime-proof:node24 --builder atlantislab/builder-node24-proof:latest --buildpack /tmp/buildpack-yarn-workspace-0.1.1.cnb --pull-policy if-not-present --trust-builder --path /tmp/buildpacks-pnp-cjs.TRjHO3 --clear-cache
Successfully built image 'atls/pnp-cjs-runtime-proof:node24'

docker run --rm atls/pnp-cjs-runtime-proof:node24
pnp-cjs-runtime-ok
```
- Builder proof
```text
./builders/build-local.sh base
Successfully created builder image 'atlantislab/builder-base:24'

docker run --rm --entrypoint node atlantislab/builder-base:24 -v
v24.15.0
```
- Diff hygiene
```text
git diff --check
```
