### PR TITLE
fix(workflows): cleanup publish registry drift

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,17 +1,11 @@
 compressionLevel: mixed
 
-defaultSemverRangePrefix: ""
-
 enableGlobalCache: true
+
+preferReuse: true
 
 globalFolder: ../.yarn/berry
 
-npmRegistryServer: "https://registry.npmjs.org"
-
-npmScopes:
-  atls:
-    npmRegistryServer: "https://registry.npmjs.org"
-
-preferReuse: true
+defaultSemverRangePrefix: ''
 
 yarnPath: .yarn/releases/yarn-remote.cjs


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#40

## Как проверять
### До фикса
1. Контекст: `atls/buildpacks` на `master` после failed publish run `25829253328`.
Действие: открыть `.yarnrc.yml`.
Ожидаемый результат: в файле есть publish registry настройки, записанные workflow шагом `yarn config set`.

### После фикса
1. Контекст: ветка `fix/cleanup-yarnrc-publish-drift`.
Действие: сравнить `.yarnrc.yml` с состоянием merge-commit `fafefda20e34612ad146ae8092e107bab691a41c` до bot-commit `64968e6`.
Ожидаемый результат: файл совпадает с pre-bot состоянием: без `npmRegistryServer`, без `npmScopes`, с прежним `defaultSemverRangePrefix: ''`.

## Пруфы
- Drift check
```text
test "$(git show fafefda20e34612ad146ae8092e107bab691a41c:.yarnrc.yml)" = "$(cat .yarnrc.yml)" && echo yarnrc_matches_pre_bot_commit
yarnrc_matches_pre_bot_commit
```

- Diff hygiene
```text
git diff --check
```
