### PR TITLE
feat(buildpacks): add docker release workflow

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -22,7 +22,6 @@ on:
 env:
   STACK_ID: tech.atlantislab.stacks.node
   PACK_VERSION: 0.40.4
-  PLATFORMS: linux/amd64,linux/arm64
 
 concurrency:
   group: docker-release
@@ -77,7 +76,7 @@ jobs:
           build-args: |
             node_image=${{ inputs.node_image }}
             stack_id=${{ env.STACK_ID }}
-          platforms: ${{ env.PLATFORMS }}
+          platforms: linux/amd64,linux/arm64
           pull: true
           push: true
           tags: atlantislab/stack-node:base
@@ -117,7 +116,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           build-args: base_image=atlantislab/stack-node:base
-          platforms: ${{ env.PLATFORMS }}
+          platforms: linux/amd64,linux/arm64
           pull: true
           push: true
           tags: atlantislab/stack-node:${{ matrix.tag }}

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -45,6 +45,9 @@ jobs:
           [[ "${EXPECTED_NODE_MAJOR}" =~ ^[0-9]+$ ]]
           [[ "${NODE_IMAGE}" =~ ^[A-Za-z0-9][A-Za-z0-9._:/@-]+$ ]]
 
+      - name: Verify Node.js major before publishing
+        run: docker run --rm --pull always "${NODE_IMAGE}" node --version | grep "^v${EXPECTED_NODE_MAJOR}\\."
+
   build-stack-base:
     name: Build stack base
     needs: validate-inputs

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -29,8 +29,25 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate-inputs:
+    name: Validate release inputs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      BUILDER_TAG: ${{ inputs.builder_tag }}
+      EXPECTED_NODE_MAJOR: ${{ inputs.expected_node_major }}
+      NODE_IMAGE: ${{ inputs.node_image }}
+    steps:
+      - name: Validate dispatcher inputs
+        run: |
+          [[ "${BUILDER_TAG}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]
+          [[ "${EXPECTED_NODE_MAJOR}" =~ ^[0-9]+$ ]]
+          [[ "${NODE_IMAGE}" =~ ^[A-Za-z0-9][A-Za-z0-9._:/@-]+$ ]]
+
   build-stack-base:
     name: Build stack base
+    needs: validate-inputs
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -104,6 +121,7 @@ jobs:
 
   publish-extensions:
     name: Publish extension ${{ matrix.name }}
+    needs: validate-inputs
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -141,6 +159,7 @@ jobs:
 
   publish-buildpack-components:
     name: Publish buildpack ${{ matrix.name }}
+    needs: validate-inputs
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -240,7 +259,9 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Publish atlantislab/builder-base:${{ inputs.builder_tag }}
-        run: pack builder create atlantislab/builder-base:${{ inputs.builder_tag }} --verbose --config builders/base/builder.toml --publish
+        env:
+          BUILDER_TAG: ${{ inputs.builder_tag }}
+        run: pack builder create "atlantislab/builder-base:${BUILDER_TAG}" --verbose --config builders/base/builder.toml --publish
 
   verify-manifests:
     name: Verify manifest ${{ matrix.image }}
@@ -260,8 +281,10 @@ jobs:
           - atlantislab/buildpack-extension-curl:0.0.1
     steps:
       - name: Verify linux/amd64 and linux/arm64
+        env:
+          IMAGE: ${{ matrix.image }}
         run: |
-          docker buildx imagetools inspect ${{ matrix.image }} | tee manifest.txt
+          docker buildx imagetools inspect "${IMAGE}" | tee manifest.txt
           grep -q linux/amd64 manifest.txt
           grep -q linux/arm64 manifest.txt
 
@@ -282,8 +305,18 @@ jobs:
             entrypoint: ''
             command: node --version
           - image: atlantislab/builder-base:${{ inputs.builder_tag }}
-            entrypoint: --entrypoint node
+            entrypoint: node
             command: --version
     steps:
       - name: Verify Node.js major
-        run: docker run --rm --pull always ${{ matrix.entrypoint }} ${{ matrix.image }} ${{ matrix.command }} | grep '^v${{ inputs.expected_node_major }}\.'
+        env:
+          COMMAND: ${{ matrix.command }}
+          ENTRYPOINT: ${{ matrix.entrypoint }}
+          EXPECTED_NODE_MAJOR: ${{ inputs.expected_node_major }}
+          IMAGE: ${{ matrix.image }}
+        run: |
+          if [[ -n "${ENTRYPOINT}" ]]; then
+            docker run --rm --pull always --entrypoint "${ENTRYPOINT}" "${IMAGE}" ${COMMAND} | grep "^v${EXPECTED_NODE_MAJOR}\\."
+          else
+            docker run --rm --pull always "${IMAGE}" ${COMMAND} | grep "^v${EXPECTED_NODE_MAJOR}\\."
+          fi

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -1,0 +1,209 @@
+name: Docker release
+
+on:
+  workflow_dispatch:
+    inputs:
+      node_image:
+        description: Node base image for stack-node:base
+        required: true
+        default: node:24-slim
+        type: string
+      expected_node_major:
+        description: Expected Node.js major version in released images
+        required: true
+        default: '24'
+        type: string
+      builder_tag:
+        description: builder-base tag to publish
+        required: true
+        default: '24'
+        type: string
+
+env:
+  DOCKER_NAMESPACE: atlantislab
+  STACK_ID: tech.atlantislab.stacks.node
+  STACK_IMAGE: atlantislab/stack-node
+  BUILDER_IMAGE: atlantislab/builder-base
+  PACK_VERSION: 0.40.4
+  TARGET_LINUX_AMD64: linux/amd64
+  TARGET_LINUX_ARM64: linux/arm64
+  PLATFORMS: linux/amd64,linux/arm64
+
+concurrency:
+  group: docker-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release Docker artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.expected_node_major }}
+          cache: yarn
+
+      - name: Install dependencies
+        run: |
+          set -euo pipefail
+
+          corepack enable
+          yarn install --immutable
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push stack base image
+        uses: docker/build-push-action@v7.1.0
+        with:
+          context: stacks/node/base
+          build-args: |
+            node_image=${{ inputs.node_image }}
+            stack_id=${{ env.STACK_ID }}
+          platforms: ${{ env.PLATFORMS }}
+          pull: true
+          push: true
+          tags: ${{ env.STACK_IMAGE }}:base
+
+      - name: Build and push stack build image
+        uses: docker/build-push-action@v7.1.0
+        with:
+          context: stacks/node/build
+          build-args: |
+            base_image=${{ env.STACK_IMAGE }}:base
+          platforms: ${{ env.PLATFORMS }}
+          pull: true
+          push: true
+          tags: ${{ env.STACK_IMAGE }}:build
+
+      - name: Build and push stack run image
+        uses: docker/build-push-action@v7.1.0
+        with:
+          context: stacks/node/run
+          build-args: |
+            base_image=${{ env.STACK_IMAGE }}:base
+          platforms: ${{ env.PLATFORMS }}
+          pull: true
+          push: true
+          tags: ${{ env.STACK_IMAGE }}:run
+
+      - name: Install pack
+        run: |
+          set -euo pipefail
+
+          archive="pack-v${PACK_VERSION}-linux.tgz"
+          cd /tmp
+          curl -sSLO "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/${archive}"
+          curl -sSLO "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/${archive}.sha256"
+          sha256sum --check "${archive}.sha256"
+          sudo tar -C /usr/local/bin -xzf "${archive}" pack
+          pack version
+
+      - name: Package and publish extensions
+        run: |
+          set -euo pipefail
+
+          package_extension() {
+            local image="$1"
+            local directory="$2"
+
+            pushd "${directory}"
+            pack extension package "${image}" \
+              --target "${TARGET_LINUX_AMD64}" \
+              --target "${TARGET_LINUX_ARM64}" \
+              --publish
+            popd
+          }
+
+          package_extension "${DOCKER_NAMESPACE}/buildpack-extension-curl:0.0.1" extensions/curl
+          package_extension "${DOCKER_NAMESPACE}/buildpack-extension-htop:0.0.1" extensions/htop
+          package_extension "${DOCKER_NAMESPACE}/buildpack-extension-graphql-hive:0.0.1" extensions/graphql-hive
+
+      - name: Build buildpack workspaces
+        run: |
+          set -euo pipefail
+
+          yarn workspace @atls/buildpack-yarn-install build
+          yarn workspace @atls/buildpack-yarn-cache build
+          yarn workspace @atls/buildpack-yarn-workspace-start build
+
+      - name: Package and publish buildpacks
+        run: |
+          set -euo pipefail
+
+          package_buildpack() {
+            local image="$1"
+            local directory="$2"
+
+            pushd "${directory}"
+            pack buildpack package "${image}" \
+              --config ./package.toml \
+              --target "${TARGET_LINUX_AMD64}" \
+              --target "${TARGET_LINUX_ARM64}" \
+              --publish
+            popd
+          }
+
+          package_buildpack "${DOCKER_NAMESPACE}/buildpack-require-extension:0.1.1" buildpacks/require-extension
+          package_buildpack "${DOCKER_NAMESPACE}/buildpack-yarn-install:0.1.1" buildpacks/yarn-install
+          package_buildpack "${DOCKER_NAMESPACE}/buildpack-yarn-cache:0.1.1" buildpacks/yarn-cache
+          package_buildpack "${DOCKER_NAMESPACE}/buildpack-yarn-workspace-start:0.1.1" buildpacks/yarn-workspace-start
+          package_buildpack "${DOCKER_NAMESPACE}/buildpack-yarn-workspace:0.1.1" buildpacks/yarn-workspace
+
+      - name: Create and publish builder
+        run: |
+          pack builder create "${BUILDER_IMAGE}:${{ inputs.builder_tag }}" \
+            --verbose \
+            --config builders/base/builder.toml \
+            --publish
+
+      - name: Verify published artifacts
+        run: |
+          set -euo pipefail
+
+          require_platforms() {
+            local image="$1"
+            local report
+            report="$(mktemp)"
+
+            docker buildx imagetools inspect "${image}" | tee "${report}"
+            grep -q "${TARGET_LINUX_AMD64}" "${report}"
+            grep -q "${TARGET_LINUX_ARM64}" "${report}"
+          }
+
+          require_node_major() {
+            local image="$1"
+            local entrypoint="${2:-}"
+            local version
+
+            if [[ -n "${entrypoint}" ]]; then
+              version="$(docker run --rm --pull always --entrypoint "${entrypoint}" "${image}" --version)"
+            else
+              version="$(docker run --rm --pull always "${image}" node --version)"
+            fi
+
+            [[ "${version}" =~ ^v${{ inputs.expected_node_major }}\. ]]
+          }
+
+          require_platforms "${STACK_IMAGE}:base"
+          require_platforms "${STACK_IMAGE}:build"
+          require_platforms "${STACK_IMAGE}:run"
+          require_platforms "${BUILDER_IMAGE}:${{ inputs.builder_tag }}"
+          require_platforms "${DOCKER_NAMESPACE}/buildpack-yarn-workspace:0.1.1"
+          require_platforms "${DOCKER_NAMESPACE}/buildpack-extension-curl:0.0.1"
+
+          require_node_major "${STACK_IMAGE}:build"
+          require_node_major "${STACK_IMAGE}:run"
+          require_node_major "${BUILDER_IMAGE}:${{ inputs.builder_tag }}" node

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -20,13 +20,8 @@ on:
         type: string
 
 env:
-  DOCKER_NAMESPACE: atlantislab
   STACK_ID: tech.atlantislab.stacks.node
-  STACK_IMAGE: atlantislab/stack-node
-  BUILDER_IMAGE: atlantislab/builder-base
   PACK_VERSION: 0.40.4
-  TARGET_LINUX_AMD64: linux/amd64
-  TARGET_LINUX_ARM64: linux/arm64
   PLATFORMS: linux/amd64,linux/arm64
 
 concurrency:
@@ -34,27 +29,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: Release Docker artifacts
+  build-stack-base:
+    name: Build stack base
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ inputs.expected_node_major }}
-          cache: yarn
-
-      - name: Install dependencies
-        run: |
-          set -euo pipefail
-
-          corepack enable
-          yarn install --immutable
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v4.0.0
@@ -68,7 +50,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push stack base image
+      - name: Publish atlantislab/stack-node:base
         uses: docker/build-push-action@v7.1.0
         with:
           context: stacks/node/base
@@ -78,135 +60,230 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
           pull: true
           push: true
-          tags: ${{ env.STACK_IMAGE }}:base
+          tags: atlantislab/stack-node:base
 
-      - name: Build and push stack build image
+  build-stack:
+    name: Build stack ${{ matrix.tag }}
+    needs: build-stack-base
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tag: build
+            context: stacks/node/build
+          - tag: run
+            context: stacks/node/run
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v4.0.0
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish atlantislab/stack-node:${{ matrix.tag }}
         uses: docker/build-push-action@v7.1.0
         with:
-          context: stacks/node/build
-          build-args: |
-            base_image=${{ env.STACK_IMAGE }}:base
+          context: ${{ matrix.context }}
+          build-args: base_image=atlantislab/stack-node:base
           platforms: ${{ env.PLATFORMS }}
           pull: true
           push: true
-          tags: ${{ env.STACK_IMAGE }}:build
+          tags: atlantislab/stack-node:${{ matrix.tag }}
 
-      - name: Build and push stack run image
-        uses: docker/build-push-action@v7.1.0
+  publish-extensions:
+    name: Publish extension ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: curl
+            directory: extensions/curl
+            image: atlantislab/buildpack-extension-curl:0.0.1
+          - name: htop
+            directory: extensions/htop
+            image: atlantislab/buildpack-extension-htop:0.0.1
+          - name: graphql-hive
+            directory: extensions/graphql-hive
+            image: atlantislab/buildpack-extension-graphql-hive:0.0.1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pack
+        uses: buildpacks/github-actions/setup-pack@v5.12.1
         with:
-          context: stacks/node/run
-          build-args: |
-            base_image=${{ env.STACK_IMAGE }}:base
-          platforms: ${{ env.PLATFORMS }}
-          pull: true
-          push: true
-          tags: ${{ env.STACK_IMAGE }}:run
+          pack-version: ${{ env.PACK_VERSION }}
 
-      - name: Install pack
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish ${{ matrix.image }}
+        working-directory: ${{ matrix.directory }}
+        run: pack extension package ${{ matrix.image }} --target linux/amd64 --target linux/arm64 --publish
+
+  publish-buildpack-components:
+    name: Publish buildpack ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: require-extension
+            directory: buildpacks/require-extension
+            image: atlantislab/buildpack-require-extension:0.1.1
+          - name: yarn-install
+            directory: buildpacks/yarn-install
+            image: atlantislab/buildpack-yarn-install:0.1.1
+          - name: yarn-cache
+            directory: buildpacks/yarn-cache
+            image: atlantislab/buildpack-yarn-cache:0.1.1
+          - name: yarn-workspace-start
+            directory: buildpacks/yarn-workspace-start
+            image: atlantislab/buildpack-yarn-workspace-start:0.1.1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.expected_node_major }}
+          cache: yarn
+
+      - name: Install dependencies
         run: |
-          set -euo pipefail
+          corepack enable
+          yarn install --immutable
 
-          archive="pack-v${PACK_VERSION}-linux.tgz"
-          cd /tmp
-          curl -sSLO "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/${archive}"
-          curl -sSLO "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/${archive}.sha256"
-          sha256sum --check "${archive}.sha256"
-          sudo tar -C /usr/local/bin -xzf "${archive}" pack
-          pack version
+      - name: Setup pack
+        uses: buildpacks/github-actions/setup-pack@v5.12.1
+        with:
+          pack-version: ${{ env.PACK_VERSION }}
 
-      - name: Package and publish extensions
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish ${{ matrix.image }}
+        working-directory: ${{ matrix.directory }}
+        run: pack buildpack package ${{ matrix.image }} --config ./package.toml --target linux/amd64 --target linux/arm64 --publish
+
+  publish-buildpack-group:
+    name: Publish buildpack group
+    needs: publish-buildpack-components
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pack
+        uses: buildpacks/github-actions/setup-pack@v5.12.1
+        with:
+          pack-version: ${{ env.PACK_VERSION }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish atlantislab/buildpack-yarn-workspace:0.1.1
+        working-directory: buildpacks/yarn-workspace
+        run: pack buildpack package atlantislab/buildpack-yarn-workspace:0.1.1 --config ./package.toml --target linux/amd64 --target linux/arm64 --publish
+
+  publish-builder:
+    name: Publish builder
+    needs:
+      - build-stack
+      - publish-extensions
+      - publish-buildpack-group
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pack
+        uses: buildpacks/github-actions/setup-pack@v5.12.1
+        with:
+          pack-version: ${{ env.PACK_VERSION }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish atlantislab/builder-base:${{ inputs.builder_tag }}
+        run: pack builder create atlantislab/builder-base:${{ inputs.builder_tag }} --verbose --config builders/base/builder.toml --publish
+
+  verify-manifests:
+    name: Verify manifest ${{ matrix.image }}
+    needs: publish-builder
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - atlantislab/stack-node:base
+          - atlantislab/stack-node:build
+          - atlantislab/stack-node:run
+          - atlantislab/builder-base:${{ inputs.builder_tag }}
+          - atlantislab/buildpack-yarn-workspace:0.1.1
+          - atlantislab/buildpack-extension-curl:0.0.1
+    steps:
+      - name: Verify linux/amd64 and linux/arm64
         run: |
-          set -euo pipefail
+          docker buildx imagetools inspect ${{ matrix.image }} | tee manifest.txt
+          grep -q linux/amd64 manifest.txt
+          grep -q linux/arm64 manifest.txt
 
-          package_extension() {
-            local image="$1"
-            local directory="$2"
-
-            pushd "${directory}"
-            pack extension package "${image}" \
-              --target "${TARGET_LINUX_AMD64}" \
-              --target "${TARGET_LINUX_ARM64}" \
-              --publish
-            popd
-          }
-
-          package_extension "${DOCKER_NAMESPACE}/buildpack-extension-curl:0.0.1" extensions/curl
-          package_extension "${DOCKER_NAMESPACE}/buildpack-extension-htop:0.0.1" extensions/htop
-          package_extension "${DOCKER_NAMESPACE}/buildpack-extension-graphql-hive:0.0.1" extensions/graphql-hive
-
-      - name: Build buildpack workspaces
-        run: |
-          set -euo pipefail
-
-          yarn workspace @atls/buildpack-yarn-install build
-          yarn workspace @atls/buildpack-yarn-cache build
-          yarn workspace @atls/buildpack-yarn-workspace-start build
-
-      - name: Package and publish buildpacks
-        run: |
-          set -euo pipefail
-
-          package_buildpack() {
-            local image="$1"
-            local directory="$2"
-
-            pushd "${directory}"
-            pack buildpack package "${image}" \
-              --config ./package.toml \
-              --target "${TARGET_LINUX_AMD64}" \
-              --target "${TARGET_LINUX_ARM64}" \
-              --publish
-            popd
-          }
-
-          package_buildpack "${DOCKER_NAMESPACE}/buildpack-require-extension:0.1.1" buildpacks/require-extension
-          package_buildpack "${DOCKER_NAMESPACE}/buildpack-yarn-install:0.1.1" buildpacks/yarn-install
-          package_buildpack "${DOCKER_NAMESPACE}/buildpack-yarn-cache:0.1.1" buildpacks/yarn-cache
-          package_buildpack "${DOCKER_NAMESPACE}/buildpack-yarn-workspace-start:0.1.1" buildpacks/yarn-workspace-start
-          package_buildpack "${DOCKER_NAMESPACE}/buildpack-yarn-workspace:0.1.1" buildpacks/yarn-workspace
-
-      - name: Create and publish builder
-        run: |
-          pack builder create "${BUILDER_IMAGE}:${{ inputs.builder_tag }}" \
-            --verbose \
-            --config builders/base/builder.toml \
-            --publish
-
-      - name: Verify published artifacts
-        run: |
-          set -euo pipefail
-
-          require_platforms() {
-            local image="$1"
-            local report
-            report="$(mktemp)"
-
-            docker buildx imagetools inspect "${image}" | tee "${report}"
-            grep -q "${TARGET_LINUX_AMD64}" "${report}"
-            grep -q "${TARGET_LINUX_ARM64}" "${report}"
-          }
-
-          require_node_major() {
-            local image="$1"
-            local entrypoint="${2:-}"
-            local version
-
-            if [[ -n "${entrypoint}" ]]; then
-              version="$(docker run --rm --pull always --entrypoint "${entrypoint}" "${image}" --version)"
-            else
-              version="$(docker run --rm --pull always "${image}" node --version)"
-            fi
-
-            [[ "${version}" =~ ^v${{ inputs.expected_node_major }}\. ]]
-          }
-
-          require_platforms "${STACK_IMAGE}:base"
-          require_platforms "${STACK_IMAGE}:build"
-          require_platforms "${STACK_IMAGE}:run"
-          require_platforms "${BUILDER_IMAGE}:${{ inputs.builder_tag }}"
-          require_platforms "${DOCKER_NAMESPACE}/buildpack-yarn-workspace:0.1.1"
-          require_platforms "${DOCKER_NAMESPACE}/buildpack-extension-curl:0.0.1"
-
-          require_node_major "${STACK_IMAGE}:build"
-          require_node_major "${STACK_IMAGE}:run"
-          require_node_major "${BUILDER_IMAGE}:${{ inputs.builder_tag }}" node
+  verify-node:
+    name: Verify Node.js ${{ matrix.image }}
+    needs: publish-builder
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: atlantislab/stack-node:build
+            entrypoint: ''
+            command: node --version
+          - image: atlantislab/stack-node:run
+            entrypoint: ''
+            command: node --version
+          - image: atlantislab/builder-base:${{ inputs.builder_tag }}
+            entrypoint: --entrypoint node
+            command: --version
+    steps:
+      - name: Verify Node.js major
+        run: docker run --rm --pull always ${{ matrix.entrypoint }} ${{ matrix.image }} ${{ matrix.command }} | grep '^v${{ inputs.expected_node_major }}\.'

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -56,6 +56,9 @@ jobs:
           corepack enable
           yarn install --immutable
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v4.0.0
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4.0.0
 

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -22,6 +22,7 @@ on:
 env:
   STACK_ID: tech.atlantislab.stacks.node
   PACK_VERSION: 0.40.4
+  PLATFORMS: linux/amd64,linux/arm64
 
 concurrency:
   group: docker-release
@@ -76,7 +77,7 @@ jobs:
           build-args: |
             node_image=${{ inputs.node_image }}
             stack_id=${{ env.STACK_ID }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           pull: true
           push: true
           tags: atlantislab/stack-node:base
@@ -116,7 +117,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           build-args: base_image=atlantislab/stack-node:base
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           pull: true
           push: true
           tags: atlantislab/stack-node:${{ matrix.tag }}

--- a/README.md
+++ b/README.md
@@ -6,24 +6,23 @@
 
 Текущий production baseline: `Node.js 24 LTS`.
 
-Для всех операций необходим аккаунт Docker с доступом к `atlantislab`.
+Docker-релиз выполняется только через GitHub Actions workflow `Docker release`.
+Для публикации workflow использует Docker Hub secrets `DOCKERHUB_USERNAME` и `DOCKERHUB_TOKEN`.
 
-1. `/stacks/node/.../Dockerfile` - поправить версию ноды на актуальную LTS
-2. `/stacks/build.sh`
-3. Проверяем версию ноды через `docker inspect X` где Х - ID созданного образа
-4. `/stacks/push.sh`
+1. В `.github/workflows/docker-release.yaml` проверить `node_image`, `expected_node_major` и `builder_tag`.
+2. Запустить workflow `Docker release` через `workflow_dispatch`.
+3. Дождаться прохождения встроенной проверки опубликованных образов.
+4. Проверить наличие нового тега в [Docker Hub](https://hub.docker.com/r/atlantislab/builder-base/tags).
 
-На текущем этапе в Docker Hub запушены все образы из `/stacks`
+Workflow публикует:
 
-Делаем билдер:
+1. `atlantislab/stack-node:base`
+2. `atlantislab/stack-node:build`
+3. `atlantislab/stack-node:run`
+4. `atlantislab/buildpack-*`
+5. `atlantislab/builder-base:<builder_tag>`
 
-1. Собрать или подтянуть `atlantislab/stack-node:run`
-2. Собрать или подтянуть `atlantislab/stack-node:build`
-3. `/builders/build.sh` и `/builders/build-local.sh` - поправить тег билдера на актуальную major-версию Node. ВАЖНО: тег всегда меняем кроме случаев когда идет исправление созданного образа. Добавляя новый тег вы создаете новый образ под новым тегом вместе перезаписывания старого.
-4. `/builders/build.sh`
-5. Проверяем версию ноды через `docker inspect X` где Х - ID созданного образа
-6. `docker image push atlantislab/builder-base:24`
-7. Проверяем в [Docker Hub](https://hub.docker.com/r/atlantislab/builder-base/tags) - должен появится ваш образ
+Локальные shell-скрипты в `stacks`, `extensions`, `buildpacks` и `builders` не являются релизным контрактом.
 
 ## Runtime запуск Yarn PnP ESM workspace
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Workflow публикует:
 4. `atlantislab/buildpack-*`
 5. `atlantislab/builder-base:<builder_tag>`
 
-Локальные shell-скрипты в `stacks`, `extensions`, `buildpacks` и `builders` не являются релизным контрактом.
-
 ## Runtime запуск Yarn PnP ESM workspace
 
 `buildpack-yarn-workspace-start` формирует launch layer с `NODE_OPTIONS` для workspace без `node_modules`.

--- a/buildpacks/yarn-workspace-start/buildpack.toml
+++ b/buildpacks/yarn-workspace-start/buildpack.toml
@@ -7,6 +7,7 @@ name = "Yarn Workspace Start Buildpack"
 
 [metadata]
 include_files = ["dist", "bin/build", "bin/detect", "buildpack.toml"]
+pre_package = "yarn build"
 
 [[targets]]
 os = "linux"

--- a/stacks/node/base/Dockerfile
+++ b/stacks/node/base/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:24-slim
+ARG node_image=node:24-slim
+FROM ${node_image}
 
 ARG cnb_uid=1001
 ARG cnb_gid=1001


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#43

## Как проверять
### Основной сценарий
1. Контекст: GitHub Actions workflow `Docker release`
Действие: запустить workflow с default inputs `node_image=node:24-slim`, `expected_node_major=24`, `builder_tag=24`
Ожидаемый результат: workflow публикует stack images, buildpack/extension packages и `atlantislab/builder-base:24`, затем подтверждает multi-arch manifests и Node 24 runtime

### Дополнительный сценарий
1. Контекст: документация release-процесса в README
Действие: открыть порядок обновления NodeJS базового билдера
Ожидаемый результат: README ведёт к `Docker release`, а локальные shell-скрипты не описаны как штатный релизный контракт

## Пруфы
- `yarn install --immutable`
- `yarn workspace @atls/buildpack-yarn-install build`
- `yarn workspace @atls/buildpack-yarn-cache build`
- `yarn workspace @atls/buildpack-yarn-workspace-start build`
- `docker buildx build --load -t atls-stack-node-base-workflow-check --build-arg node_image=node:24-slim --build-arg stack_id=tech.atlantislab.stacks.node stacks/node/base`
- `docker run --rm atls-stack-node-base-workflow-check node --version` -> `v24.15.0`
- `pack extension package ... --format file --target linux/amd64 --target linux/arm64` для curl, htop и graphql-hive
- `pack buildpack package ... --format file --config ./package.toml --target linux/amd64 --target linux/arm64` для всех buildpacks
- `ruby -e ... YAML.load_file(...)`
- `actionlint .github/workflows/docker-release.yaml`
- `git diff --check`
