### PR TITLE
fix(workflows): verify docker release node platforms

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -16,9 +16,6 @@ on:
       - 'yarn.lock'
 
 env:
-  BUILDER_TAG: '24'
-  EXPECTED_NODE_MAJOR: '24'
-  NODE_IMAGE: node:24-slim
   STACK_ID: tech.atlantislab.stacks.node
   PACK_VERSION: 0.40.4
   PLATFORMS: linux/amd64,linux/arm64
@@ -33,15 +30,31 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      builder-tag: ${{ steps.release-config.outputs.builder-tag }}
+      node-image: ${{ steps.release-config.outputs.node-image }}
+      node-major: ${{ steps.release-config.outputs.node-major }}
     steps:
-      - name: Validate release configuration
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve release configuration
+        id: release-config
         run: |
-          [[ "${BUILDER_TAG}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]
-          [[ "${EXPECTED_NODE_MAJOR}" =~ ^[0-9]+$ ]]
-          [[ "${NODE_IMAGE}" =~ ^[A-Za-z0-9][A-Za-z0-9._:/@-]+$ ]]
+          node_image="$(awk -F= '$1 == "ARG node_image" { print $2; exit }' stacks/node/base/Dockerfile)"
+          [[ "${node_image}" =~ ^node:([0-9]+)-slim$ ]]
+
+          node_major="${BASH_REMATCH[1]}"
+
+          echo "builder-tag=${node_major}" >> "${GITHUB_OUTPUT}"
+          echo "node-image=${node_image}" >> "${GITHUB_OUTPUT}"
+          echo "node-major=${node_major}" >> "${GITHUB_OUTPUT}"
 
       - name: Verify Node.js major before publishing
-        run: docker run --rm --pull always "${NODE_IMAGE}" node --version | grep "^v${EXPECTED_NODE_MAJOR}\\."
+        env:
+          NODE_IMAGE: ${{ steps.release-config.outputs.node-image }}
+          NODE_MAJOR: ${{ steps.release-config.outputs.node-major }}
+        run: docker run --rm --pull always "${NODE_IMAGE}" node --version | grep "^v${NODE_MAJOR}\\."
 
   build-stack-base:
     name: Build stack base
@@ -70,7 +83,7 @@ jobs:
         with:
           context: stacks/node/base
           build-args: |
-            node_image=${{ env.NODE_IMAGE }}
+            node_image=${{ needs.validate-release.outputs.node-image }}
             stack_id=${{ env.STACK_ID }}
           platforms: ${{ env.PLATFORMS }}
           pull: true
@@ -184,7 +197,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.EXPECTED_NODE_MAJOR }}
+          node-version: ${{ needs.validate-release.outputs.node-major }}
           cache: yarn
 
       - name: Install dependencies
@@ -238,6 +251,7 @@ jobs:
       - build-stack
       - publish-extensions
       - publish-buildpack-group
+      - validate-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -256,7 +270,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Publish atlantislab/builder-base:${{ env.BUILDER_TAG }}
+      - name: Publish builder
+        env:
+          BUILDER_TAG: ${{ needs.validate-release.outputs.builder-tag }}
         run: pack builder create "atlantislab/builder-base:${BUILDER_TAG}" --verbose --config builders/base/builder.toml --publish
 
   verify-manifests:
@@ -285,12 +301,16 @@ jobs:
 
   verify-builder-manifest:
     name: Verify builder manifest
-    needs: publish-builder
+    needs:
+      - publish-builder
+      - validate-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - name: Verify linux/amd64 and linux/arm64
+        env:
+          BUILDER_TAG: ${{ needs.validate-release.outputs.builder-tag }}
         run: |
           docker buildx imagetools inspect "atlantislab/builder-base:${BUILDER_TAG}" | tee manifest.txt
           grep -q linux/amd64 manifest.txt
@@ -298,7 +318,9 @@ jobs:
 
   verify-node:
     name: Verify Node.js ${{ matrix.image }} ${{ matrix.platform }}
-    needs: publish-builder
+    needs:
+      - publish-builder
+      - validate-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -330,7 +352,7 @@ jobs:
         env:
           COMMAND: ${{ matrix.command }}
           ENTRYPOINT: ${{ matrix.entrypoint }}
-          EXPECTED_NODE_MAJOR: ${{ env.EXPECTED_NODE_MAJOR }}
+          EXPECTED_NODE_MAJOR: ${{ needs.validate-release.outputs.node-major }}
           IMAGE: ${{ matrix.image }}
           PLATFORM: ${{ matrix.platform }}
         run: |
@@ -342,7 +364,9 @@ jobs:
 
   verify-builder-node:
     name: Verify Node.js builder ${{ matrix.platform }}
-    needs: publish-builder
+    needs:
+      - publish-builder
+      - validate-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -358,5 +382,7 @@ jobs:
 
       - name: Verify Node.js major
         env:
+          BUILDER_TAG: ${{ needs.validate-release.outputs.builder-tag }}
+          EXPECTED_NODE_MAJOR: ${{ needs.validate-release.outputs.node-major }}
           PLATFORM: ${{ matrix.platform }}
         run: docker run --rm --pull always --platform "${PLATFORM}" --entrypoint node "atlantislab/builder-base:${BUILDER_TAG}" --version | grep "^v${EXPECTED_NODE_MAJOR}\\."

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -7,12 +7,14 @@ on:
     paths:
       - '.github/workflows/docker-release.yaml'
       - '.yarn/**'
+      - '.yarnrc.yml'
       - 'builders/**'
       - 'buildpacks/**'
       - 'extensions/**'
       - 'libcnb/**'
       - 'package.json'
       - 'stacks/**'
+      - 'tsconfig.json'
       - 'yarn.lock'
 
 env:

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -272,7 +272,6 @@ jobs:
           - atlantislab/stack-node:base
           - atlantislab/stack-node:build
           - atlantislab/stack-node:run
-          - atlantislab/builder-base:24
           - atlantislab/buildpack-yarn-workspace:0.1.1
           - atlantislab/buildpack-extension-curl:0.0.1
     steps:
@@ -281,6 +280,19 @@ jobs:
           IMAGE: ${{ matrix.image }}
         run: |
           docker buildx imagetools inspect "${IMAGE}" | tee manifest.txt
+          grep -q linux/amd64 manifest.txt
+          grep -q linux/arm64 manifest.txt
+
+  verify-builder-manifest:
+    name: Verify builder manifest
+    needs: publish-builder
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify linux/amd64 and linux/arm64
+        run: |
+          docker buildx imagetools inspect "atlantislab/builder-base:${BUILDER_TAG}" | tee manifest.txt
           grep -q linux/amd64 manifest.txt
           grep -q linux/arm64 manifest.txt
 
@@ -310,14 +322,6 @@ jobs:
             platform: linux/arm64
             entrypoint: ''
             command: node --version
-          - image: atlantislab/builder-base:24
-            platform: linux/amd64
-            entrypoint: node
-            command: --version
-          - image: atlantislab/builder-base:24
-            platform: linux/arm64
-            entrypoint: node
-            command: --version
     steps:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v4.0.0
@@ -335,3 +339,24 @@ jobs:
           else
             docker run --rm --pull always --platform "${PLATFORM}" "${IMAGE}" ${COMMAND} | grep "^v${EXPECTED_NODE_MAJOR}\\."
           fi
+
+  verify-builder-node:
+    name: Verify Node.js builder ${{ matrix.platform }}
+    needs: publish-builder
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v4.0.0
+
+      - name: Verify Node.js major
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: docker run --rm --pull always --platform "${PLATFORM}" --entrypoint node "atlantislab/builder-base:${BUILDER_TAG}" --version | grep "^v${EXPECTED_NODE_MAJOR}\\."

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -1,9 +1,7 @@
 name: Docker release
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - master
     paths:
@@ -32,7 +30,6 @@ concurrency:
 jobs:
   validate-release:
     name: Validate release
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -1,25 +1,26 @@
 name: Docker release
 
 on:
-  workflow_dispatch:
-    inputs:
-      node_image:
-        description: Node base image for stack-node:base
-        required: true
-        default: node:24-slim
-        type: string
-      expected_node_major:
-        description: Expected Node.js major version in released images
-        required: true
-        default: '24'
-        type: string
-      builder_tag:
-        description: builder-base tag to publish
-        required: true
-        default: '24'
-        type: string
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+    paths:
+      - '.github/workflows/docker-release.yaml'
+      - '.yarn/**'
+      - 'builders/**'
+      - 'buildpacks/**'
+      - 'extensions/**'
+      - 'libcnb/**'
+      - 'package.json'
+      - 'stacks/**'
+      - 'yarn.lock'
 
 env:
+  BUILDER_TAG: '24'
+  EXPECTED_NODE_MAJOR: '24'
+  NODE_IMAGE: node:24-slim
   STACK_ID: tech.atlantislab.stacks.node
   PACK_VERSION: 0.40.4
   PLATFORMS: linux/amd64,linux/arm64
@@ -29,17 +30,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  validate-inputs:
-    name: Validate release inputs
+  validate-release:
+    name: Validate release
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      BUILDER_TAG: ${{ inputs.builder_tag }}
-      EXPECTED_NODE_MAJOR: ${{ inputs.expected_node_major }}
-      NODE_IMAGE: ${{ inputs.node_image }}
     steps:
-      - name: Validate dispatcher inputs
+      - name: Validate release configuration
         run: |
           [[ "${BUILDER_TAG}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]
           [[ "${EXPECTED_NODE_MAJOR}" =~ ^[0-9]+$ ]]
@@ -50,7 +48,7 @@ jobs:
 
   build-stack-base:
     name: Build stack base
-    needs: validate-inputs
+    needs: validate-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -75,7 +73,7 @@ jobs:
         with:
           context: stacks/node/base
           build-args: |
-            node_image=${{ inputs.node_image }}
+            node_image=${{ env.NODE_IMAGE }}
             stack_id=${{ env.STACK_ID }}
           platforms: ${{ env.PLATFORMS }}
           pull: true
@@ -124,7 +122,7 @@ jobs:
 
   publish-extensions:
     name: Publish extension ${{ matrix.name }}
-    needs: validate-inputs
+    needs: validate-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -162,7 +160,7 @@ jobs:
 
   publish-buildpack-components:
     name: Publish buildpack ${{ matrix.name }}
-    needs: validate-inputs
+    needs: validate-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -189,7 +187,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ inputs.expected_node_major }}
+          node-version: ${{ env.EXPECTED_NODE_MAJOR }}
           cache: yarn
 
       - name: Install dependencies
@@ -261,9 +259,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Publish atlantislab/builder-base:${{ inputs.builder_tag }}
-        env:
-          BUILDER_TAG: ${{ inputs.builder_tag }}
+      - name: Publish atlantislab/builder-base:${{ env.BUILDER_TAG }}
         run: pack builder create "atlantislab/builder-base:${BUILDER_TAG}" --verbose --config builders/base/builder.toml --publish
 
   verify-manifests:
@@ -279,7 +275,7 @@ jobs:
           - atlantislab/stack-node:base
           - atlantislab/stack-node:build
           - atlantislab/stack-node:run
-          - atlantislab/builder-base:${{ inputs.builder_tag }}
+          - atlantislab/builder-base:24
           - atlantislab/buildpack-yarn-workspace:0.1.1
           - atlantislab/buildpack-extension-curl:0.0.1
     steps:
@@ -317,11 +313,11 @@ jobs:
             platform: linux/arm64
             entrypoint: ''
             command: node --version
-          - image: atlantislab/builder-base:${{ inputs.builder_tag }}
+          - image: atlantislab/builder-base:24
             platform: linux/amd64
             entrypoint: node
             command: --version
-          - image: atlantislab/builder-base:${{ inputs.builder_tag }}
+          - image: atlantislab/builder-base:24
             platform: linux/arm64
             entrypoint: node
             command: --version
@@ -333,7 +329,7 @@ jobs:
         env:
           COMMAND: ${{ matrix.command }}
           ENTRYPOINT: ${{ matrix.entrypoint }}
-          EXPECTED_NODE_MAJOR: ${{ inputs.expected_node_major }}
+          EXPECTED_NODE_MAJOR: ${{ env.EXPECTED_NODE_MAJOR }}
           IMAGE: ${{ matrix.image }}
           PLATFORM: ${{ matrix.platform }}
         run: |

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -292,7 +292,7 @@ jobs:
           grep -q linux/arm64 manifest.txt
 
   verify-node:
-    name: Verify Node.js ${{ matrix.image }}
+    name: Verify Node.js ${{ matrix.image }} ${{ matrix.platform }}
     needs: publish-builder
     runs-on: ubuntu-latest
     permissions:
@@ -302,24 +302,43 @@ jobs:
       matrix:
         include:
           - image: atlantislab/stack-node:build
+            platform: linux/amd64
+            entrypoint: ''
+            command: node --version
+          - image: atlantislab/stack-node:build
+            platform: linux/arm64
             entrypoint: ''
             command: node --version
           - image: atlantislab/stack-node:run
+            platform: linux/amd64
+            entrypoint: ''
+            command: node --version
+          - image: atlantislab/stack-node:run
+            platform: linux/arm64
             entrypoint: ''
             command: node --version
           - image: atlantislab/builder-base:${{ inputs.builder_tag }}
+            platform: linux/amd64
+            entrypoint: node
+            command: --version
+          - image: atlantislab/builder-base:${{ inputs.builder_tag }}
+            platform: linux/arm64
             entrypoint: node
             command: --version
     steps:
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v4.0.0
+
       - name: Verify Node.js major
         env:
           COMMAND: ${{ matrix.command }}
           ENTRYPOINT: ${{ matrix.entrypoint }}
           EXPECTED_NODE_MAJOR: ${{ inputs.expected_node_major }}
           IMAGE: ${{ matrix.image }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
           if [[ -n "${ENTRYPOINT}" ]]; then
-            docker run --rm --pull always --entrypoint "${ENTRYPOINT}" "${IMAGE}" ${COMMAND} | grep "^v${EXPECTED_NODE_MAJOR}\\."
+            docker run --rm --pull always --platform "${PLATFORM}" --entrypoint "${ENTRYPOINT}" "${IMAGE}" ${COMMAND} | grep "^v${EXPECTED_NODE_MAJOR}\\."
           else
-            docker run --rm --pull always "${IMAGE}" ${COMMAND} | grep "^v${EXPECTED_NODE_MAJOR}\\."
+            docker run --rm --pull always --platform "${PLATFORM}" "${IMAGE}" ${COMMAND} | grep "^v${EXPECTED_NODE_MAJOR}\\."
           fi

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 Текущий production baseline: `Node.js 24 LTS`.
 
-Docker-релиз выполняется только через GitHub Actions workflow `Docker release`.
+Docker-релиз выполняется через GitHub Actions workflow `Docker release` после merge в `master`.
 Для публикации workflow использует Docker Hub secrets `DOCKERHUB_USERNAME` и `DOCKERHUB_TOKEN`.
 
-1. В `.github/workflows/docker-release.yaml` проверить `node_image`, `expected_node_major` и `builder_tag`.
-2. Запустить workflow `Docker release` через `workflow_dispatch`.
-3. Дождаться прохождения встроенной проверки опубликованных образов.
+1. В `.github/workflows/docker-release.yaml` обновить `NODE_IMAGE`, `EXPECTED_NODE_MAJOR` и `BUILDER_TAG`.
+2. Вмержить PR с релизными изменениями в `master`.
+3. Дождаться прохождения workflow `Docker release`.
 4. Проверить наличие нового тега в [Docker Hub](https://hub.docker.com/r/atlantislab/builder-base/tags).
 
 Workflow публикует:
@@ -20,7 +20,7 @@ Workflow публикует:
 2. `atlantislab/stack-node:build`
 3. `atlantislab/stack-node:run`
 4. `atlantislab/buildpack-*`
-5. `atlantislab/builder-base:<builder_tag>`
+5. `atlantislab/builder-base:<BUILDER_TAG>`
 
 ## Runtime запуск Yarn PnP ESM workspace
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 ## Порядок обновления версии `NodeJS` базового билдера
 
-Текущий production baseline: `Node.js 24 LTS`.
+Текущий production baseline берётся из `ARG node_image` в `stacks/node/base/Dockerfile`.
 
 Docker-релиз выполняется через GitHub Actions workflow `Docker release` после merge в `master`.
 Для публикации workflow использует Docker Hub secrets `DOCKERHUB_USERNAME` и `DOCKERHUB_TOKEN`.
 
-1. В `.github/workflows/docker-release.yaml` обновить `NODE_IMAGE`, `EXPECTED_NODE_MAJOR` и `BUILDER_TAG`.
+1. В `stacks/node/base/Dockerfile` обновить `ARG node_image`.
 2. Вмержить PR с релизными изменениями в `master`.
 3. Дождаться прохождения workflow `Docker release`.
 4. Проверить наличие нового тега в [Docker Hub](https://hub.docker.com/r/atlantislab/builder-base/tags).
@@ -20,7 +20,7 @@ Workflow публикует:
 2. `atlantislab/stack-node:build`
 3. `atlantislab/stack-node:run`
 4. `atlantislab/buildpack-*`
-5. `atlantislab/builder-base:<BUILDER_TAG>`
+5. `atlantislab/builder-base:<Node major>`
 
 ## Runtime запуск Yarn PnP ESM workspace
 


### PR DESCRIPTION
## Таска
- atls/buildpacks#44

## Как проверять
### До фикса
1. Контекст: Docker release workflow
Действие: PR с релизными изменениями вмержен в `master`
Ожидаемый результат: Docker release не запускается штатно, потому что workflow доступен только через `workflow_dispatch`

2. Контекст: Docker release workflow, job `verify-node`
Действие: workflow запускает `docker run` для опубликованных multi-arch образов без `--platform`
Ожидаемый результат: проверяется только host/default platform runner, arm64 runtime не исполняется

3. Контекст: следующий Node baseline
Действие: нужно выпустить Node major выше текущего
Ожидаемый результат: версию надо синхронно менять в нескольких workflow-переменных и проверках

### После фикса
1. Контекст: Docker release workflow
Действие: PR с релизными изменениями вмержен в `master`
Ожидаемый результат: Docker release автоматически запускается через `push` в `master`, если изменены релизные пути

2. Контекст: Docker release workflow, job `verify-node`
Действие: workflow запускает матрицу `linux/amd64` и `linux/arm64` для `stack-node:build`, `stack-node:run` и `builder-base:<Node major>`
Ожидаемый результат: Node major проверяется внутри каждой опубликованной платформы; для arm64 перед проверкой установлен QEMU

3. Контекст: следующий Node baseline
Действие: в `stacks/node/base/Dockerfile` обновить `ARG node_image`
Ожидаемый результат: workflow выводит Node image, Node major и builder tag из этого ARG

## Пруфы
- `ruby -e ... YAML.load_file(...)`
- `actionlint .github/workflows/docker-release.yaml`
- `git diff --check`
- `bash -lc ...` parses `node_image=node:24-slim`, `node_major=24`, `builder_tag=24` from `stacks/node/base/Dockerfile`
- `docker run --rm --pull always --platform linux/amd64 atlantislab/stack-node:build node --version` -> `v24.15.0`
- `docker run --rm --pull always --platform linux/arm64 atlantislab/stack-node:build node --version` -> `v24.15.0`
- `docker run --rm --pull always --platform linux/amd64 atlantislab/stack-node:run node --version` -> `v24.15.0`
- `docker run --rm --pull always --platform linux/arm64 atlantislab/stack-node:run node --version` -> `v24.15.0`
- `docker run --rm --pull always --platform linux/amd64 --entrypoint node atlantislab/builder-base:24 --version` -> `v24.15.0`
- `docker run --rm --pull always --platform linux/arm64 --entrypoint node atlantislab/builder-base:24 --version` -> `v24.15.0`
