### PR TITLE
feat: version stack node release tags

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -176,6 +176,14 @@ jobs:
         working-directory: ${{ matrix.directory }}
         run: pack extension package ${{ matrix.image }} --target linux/amd64 --target linux/arm64 --publish
 
+      - name: Verify linux/amd64 and linux/arm64
+        env:
+          IMAGE: ${{ matrix.image }}
+        run: |
+          docker buildx imagetools inspect "${IMAGE}" | tee manifest.txt
+          grep -q linux/amd64 manifest.txt
+          grep -q linux/arm64 manifest.txt
+
   publish-buildpack-components:
     name: Publish buildpack ${{ matrix.name }}
     needs: validate-release
@@ -228,6 +236,14 @@ jobs:
         working-directory: ${{ matrix.directory }}
         run: pack buildpack package ${{ matrix.image }} --config ./package.toml --target linux/amd64 --target linux/arm64 --publish
 
+      - name: Verify linux/amd64 and linux/arm64
+        env:
+          IMAGE: ${{ matrix.image }}
+        run: |
+          docker buildx imagetools inspect "${IMAGE}" | tee manifest.txt
+          grep -q linux/amd64 manifest.txt
+          grep -q linux/arm64 manifest.txt
+
   publish-buildpack-group:
     name: Publish buildpack group
     needs: publish-buildpack-components
@@ -253,6 +269,39 @@ jobs:
         working-directory: buildpacks/yarn-workspace
         run: pack buildpack package atlantislab/buildpack-yarn-workspace:0.1.1 --config ./package.toml --target linux/amd64 --target linux/arm64 --publish
 
+      - name: Verify linux/amd64 and linux/arm64
+        env:
+          IMAGE: atlantislab/buildpack-yarn-workspace:0.1.1
+        run: |
+          docker buildx imagetools inspect "${IMAGE}" | tee manifest.txt
+          grep -q linux/amd64 manifest.txt
+          grep -q linux/arm64 manifest.txt
+
+  verify-stack-manifests:
+    name: Verify stack manifests
+    needs:
+      - build-stack
+      - validate-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify linux/amd64 and linux/arm64
+        env:
+          NODE_MAJOR: ${{ needs.validate-release.outputs.node-major }}
+        run: |
+          images=(
+            "atlantislab/stack-node:base-${NODE_MAJOR}"
+            "atlantislab/stack-node:build-${NODE_MAJOR}"
+            "atlantislab/stack-node:run-${NODE_MAJOR}"
+          )
+
+          for image in "${images[@]}"; do
+            docker buildx imagetools inspect "${image}" | tee manifest.txt
+            grep -q linux/amd64 manifest.txt
+            grep -q linux/arm64 manifest.txt
+          done
+
   publish-builder:
     name: Publish builder
     needs:
@@ -260,6 +309,7 @@ jobs:
       - publish-extensions
       - publish-buildpack-group
       - validate-release
+      - verify-stack-manifests
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -292,33 +342,6 @@ jobs:
             "${builder_config}"
 
           pack builder create "atlantislab/builder-base:${BUILDER_TAG}" --verbose --config "${builder_config}" --publish
-
-  verify-manifests:
-    name: Verify manifests
-    needs:
-      - publish-builder
-      - validate-release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Verify linux/amd64 and linux/arm64
-        env:
-          NODE_MAJOR: ${{ needs.validate-release.outputs.node-major }}
-        run: |
-          images=(
-            "atlantislab/stack-node:base-${NODE_MAJOR}"
-            "atlantislab/stack-node:build-${NODE_MAJOR}"
-            "atlantislab/stack-node:run-${NODE_MAJOR}"
-            "atlantislab/buildpack-yarn-workspace:0.1.1"
-            "atlantislab/buildpack-extension-curl:0.0.1"
-          )
-
-          for image in "${images[@]}"; do
-            docker buildx imagetools inspect "${image}" | tee manifest.txt
-            grep -q linux/amd64 manifest.txt
-            grep -q linux/arm64 manifest.txt
-          done
 
   verify-builder-manifest:
     name: Verify builder manifest

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -90,11 +90,15 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
           pull: true
           push: true
-          tags: atlantislab/stack-node:base
+          tags: |
+            atlantislab/stack-node:base-${{ needs.validate-release.outputs.node-major }}
+            atlantislab/stack-node:base
 
   build-stack:
-    name: Build stack ${{ matrix.tag }}
-    needs: build-stack-base
+    name: Build stack ${{ matrix.tag }}-${{ needs.validate-release.outputs.node-major }}
+    needs:
+      - build-stack-base
+      - validate-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -126,11 +130,13 @@ jobs:
         uses: docker/build-push-action@v7.1.0
         with:
           context: ${{ matrix.context }}
-          build-args: base_image=atlantislab/stack-node:base
+          build-args: base_image=atlantislab/stack-node:base-${{ needs.validate-release.outputs.node-major }}
           platforms: ${{ env.PLATFORMS }}
           pull: true
           push: true
-          tags: atlantislab/stack-node:${{ matrix.tag }}
+          tags: |
+            atlantislab/stack-node:${{ matrix.tag }}-${{ needs.validate-release.outputs.node-major }}
+            atlantislab/stack-node:${{ matrix.tag }}
 
   publish-extensions:
     name: Publish extension ${{ matrix.name }}
@@ -275,31 +281,44 @@ jobs:
       - name: Publish builder
         env:
           BUILDER_TAG: ${{ needs.validate-release.outputs.builder-tag }}
-        run: pack builder create "atlantislab/builder-base:${BUILDER_TAG}" --verbose --config builders/base/builder.toml --publish
+          NODE_MAJOR: ${{ needs.validate-release.outputs.node-major }}
+        run: |
+          builder_config="${RUNNER_TEMP}/builder.toml"
+          cp builders/base/builder.toml "${builder_config}"
+
+          sed -i \
+            -e "s#atlantislab/stack-node:build#atlantislab/stack-node:build-${NODE_MAJOR}#g" \
+            -e "s#atlantislab/stack-node:run#atlantislab/stack-node:run-${NODE_MAJOR}#g" \
+            "${builder_config}"
+
+          pack builder create "atlantislab/builder-base:${BUILDER_TAG}" --verbose --config "${builder_config}" --publish
 
   verify-manifests:
-    name: Verify manifest ${{ matrix.image }}
-    needs: publish-builder
+    name: Verify manifests
+    needs:
+      - publish-builder
+      - validate-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        image:
-          - atlantislab/stack-node:base
-          - atlantislab/stack-node:build
-          - atlantislab/stack-node:run
-          - atlantislab/buildpack-yarn-workspace:0.1.1
-          - atlantislab/buildpack-extension-curl:0.0.1
     steps:
       - name: Verify linux/amd64 and linux/arm64
         env:
-          IMAGE: ${{ matrix.image }}
+          NODE_MAJOR: ${{ needs.validate-release.outputs.node-major }}
         run: |
-          docker buildx imagetools inspect "${IMAGE}" | tee manifest.txt
-          grep -q linux/amd64 manifest.txt
-          grep -q linux/arm64 manifest.txt
+          images=(
+            "atlantislab/stack-node:base-${NODE_MAJOR}"
+            "atlantislab/stack-node:build-${NODE_MAJOR}"
+            "atlantislab/stack-node:run-${NODE_MAJOR}"
+            "atlantislab/buildpack-yarn-workspace:0.1.1"
+            "atlantislab/buildpack-extension-curl:0.0.1"
+          )
+
+          for image in "${images[@]}"; do
+            docker buildx imagetools inspect "${image}" | tee manifest.txt
+            grep -q linux/amd64 manifest.txt
+            grep -q linux/arm64 manifest.txt
+          done
 
   verify-builder-manifest:
     name: Verify builder manifest
@@ -319,7 +338,7 @@ jobs:
           grep -q linux/arm64 manifest.txt
 
   verify-node:
-    name: Verify Node.js ${{ matrix.image }} ${{ matrix.platform }}
+    name: Verify Node.js stack-node:${{ matrix.tag }}-${{ needs.validate-release.outputs.node-major }} ${{ matrix.platform }}
     needs:
       - publish-builder
       - validate-release
@@ -330,19 +349,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: atlantislab/stack-node:build
+          - tag: build
             platform: linux/amd64
             entrypoint: ''
             command: node --version
-          - image: atlantislab/stack-node:build
+          - tag: build
             platform: linux/arm64
             entrypoint: ''
             command: node --version
-          - image: atlantislab/stack-node:run
+          - tag: run
             platform: linux/amd64
             entrypoint: ''
             command: node --version
-          - image: atlantislab/stack-node:run
+          - tag: run
             platform: linux/arm64
             entrypoint: ''
             command: node --version
@@ -355,7 +374,7 @@ jobs:
           COMMAND: ${{ matrix.command }}
           ENTRYPOINT: ${{ matrix.entrypoint }}
           EXPECTED_NODE_MAJOR: ${{ needs.validate-release.outputs.node-major }}
-          IMAGE: ${{ matrix.image }}
+          IMAGE: atlantislab/stack-node:${{ matrix.tag }}-${{ needs.validate-release.outputs.node-major }}
           PLATFORM: ${{ matrix.platform }}
         run: |
           if [[ -n "${ENTRYPOINT}" ]]; then

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ Docker-релиз выполняется через GitHub Actions workflow `Doc
 
 Workflow публикует:
 
-1. `atlantislab/stack-node:base`
-2. `atlantislab/stack-node:build`
-3. `atlantislab/stack-node:run`
-4. `atlantislab/buildpack-*`
-5. `atlantislab/builder-base:<Node major>`
+1. `atlantislab/stack-node:base-<Node major>`
+2. `atlantislab/stack-node:build-<Node major>`
+3. `atlantislab/stack-node:run-<Node major>`
+4. `atlantislab/stack-node:base`, `atlantislab/stack-node:build`, `atlantislab/stack-node:run` как moving aliases текущего baseline
+5. `atlantislab/buildpack-*`
+6. `atlantislab/builder-base:<Node major>`, собранный из stack tags того же Node major
 
 ## Runtime запуск Yarn PnP ESM workspace
 


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#47

## Как проверять
### Основной сценарий
1. Контекст: Docker release для Node 24 baseline
Действие: workflow собирает stack images и builder после merge в `master`
Ожидаемый результат: публикуются `atlantislab/stack-node:base-24`, `atlantislab/stack-node:build-24`, `atlantislab/stack-node:run-24`; `atlantislab/builder-base:24` собирается из `build-24` и `run-24`

### Дополнительный сценарий
1. Контекст: следующий Docker release для Node 26 baseline
Действие: в `stacks/node/base/Dockerfile` обновлён `ARG node_image` на Node 26 image
Ожидаемый результат: workflow публикует `base-26`, `build-26`, `run-26` без перетирания `base-24`, `build-24`, `run-24`; moving aliases `base`, `build`, `run` остаются только текущим baseline

## Пруфы
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-release.yaml"); puts "yaml ok"'`
- `git diff --check`
- `bash -lc 'node_major=24; cp builders/base/builder.toml /tmp/builder-test.toml; sed -i.bak -e "s#atlantislab/stack-node:build#atlantislab/stack-node:build-${node_major}#g" -e "s#atlantislab/stack-node:run#atlantislab/stack-node:run-${node_major}#g" /tmp/builder-test.toml; rg -n "stack-node" /tmp/builder-test.toml'` -> `build-24`, `run-24`
