### PR TITLE
Fix builder lifecycle critical CVEs

### DIFF
--- a/builders/base/builder.toml
+++ b/builders/base/builder.toml
@@ -1,5 +1,8 @@
 [[order]]
 
+[lifecycle]
+version = "0.21.9"
+
 [build]
 image = "atlantislab/stack-node:build"
 


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#49

## Как проверять
### До фикса
1. Контекст: Docker Scout scan для atlantislab/builder-base:24
Действие: проверить critical vulnerabilities в lifecycle layer
Ожидаемый результат: До фикса: scan показывает 2 critical vulnerabilities в /cnb/lifecycle/lifecycle и /cnb/lifecycle/launcher

### После фикса
1. Контекст: локальная сборка builder image из builders/base/builder.toml
Действие: собрать builder через pack builder create и проверить Docker Scout scan локального образа
Ожидаемый результат: После фикса: scan показывает 0 critical vulnerabilities для builder image с lifecycle v0.21.9

## Пруфы
- локальная сборка builder
```text
pack builder create atlantislab/builder-base:lifecycle-0.21.9-local --config builders/base/builder.toml --pull-policy if-not-present
Successfully created builder image 'atlantislab/builder-base:lifecycle-0.21.9-local'
```

- Docker Scout для buildpacksio/lifecycle:0.21.9
```text
Target: registry://buildpacksio/lifecycle:0.21.9
vulnerabilities: 0C 0H 0M 0L
No vulnerable packages detected
```

- Docker Scout для локально собранного builder image
```text
Target: atlantislab/builder-base:lifecycle-0.21.9-local
vulnerabilities: 0C 0H 0M 0L
No vulnerable package detected
```
