### PR TITLE
feat: update Node baseline to 26

### DIFF
--- a/stacks/node/base/Dockerfile
+++ b/stacks/node/base/Dockerfile
@@ -7,6 +7,8 @@ ARG stack_id=tech.atlantislab.stacks.node
 ARG corepack_version=0.35.0
 ARG yarn_version=4.1.1
 
+ENV COREPACK_HOME=/opt/corepack
+
 # Create user and group
 RUN groupadd cnb --gid ${cnb_gid} && \
   useradd --uid ${cnb_uid} --gid ${cnb_gid} -m -s /bin/bash cnb
@@ -16,9 +18,11 @@ RUN apt-get update && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g corepack@${corepack_version} && \
+RUN mkdir -p ${COREPACK_HOME} && \
+  npm install -g corepack@${corepack_version} && \
   corepack enable && \
-  corepack prepare yarn@${yarn_version} --activate
+  corepack prepare yarn@${yarn_version} --activate && \
+  chown -R ${cnb_uid}:${cnb_gid} ${COREPACK_HOME}
 
 LABEL io.buildpacks.base.distro.name=Debian
 LABEL io.buildpacks.base.distro.version=trixie

--- a/stacks/node/base/Dockerfile
+++ b/stacks/node/base/Dockerfile
@@ -4,6 +4,8 @@ FROM ${node_image}
 ARG cnb_uid=1001
 ARG cnb_gid=1001
 ARG stack_id=tech.atlantislab.stacks.node
+ARG corepack_version=0.35.0
+ARG yarn_version=4.1.1
 
 # Create user and group
 RUN groupadd cnb --gid ${cnb_gid} && \
@@ -13,6 +15,10 @@ RUN apt-get update && \
   apt-get install -y --no-install-recommends ca-certificates && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g corepack@${corepack_version} && \
+  corepack enable && \
+  corepack prepare yarn@${yarn_version} --activate
 
 LABEL io.buildpacks.base.distro.name=Debian
 LABEL io.buildpacks.base.distro.version=trixie

--- a/stacks/node/base/Dockerfile
+++ b/stacks/node/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG node_image=node:24-slim
+ARG node_image=node:26-slim
 FROM ${node_image}
 
 ARG cnb_uid=1001
@@ -15,7 +15,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 
 LABEL io.buildpacks.base.distro.name=Debian
-LABEL io.buildpacks.base.distro.version=bookworm
+LABEL io.buildpacks.base.distro.version=trixie
 LABEL io.buildpacks.stack.id=${stack_id}
 
 # Set required CNB information


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#53

## Как проверять
### Основной сценарий
1. Контекст: GitHub Actions workflow Docker release
Действие: вмержить PR в master
Ожидаемый результат: workflow берёт node:26-slim из stacks/node/base/Dockerfile, собирает временные release-теги, проходит Docker Scout gate и публикует atlantislab/builder-base:26 вместе с atlantislab/stack-node:base-26, atlantislab/stack-node:build-26 и atlantislab/stack-node:run-26

### Дополнительный сценарий
1. Контекст: Docker Hub теги release images
Действие: проверить опубликованные теги после прохождения workflow
Ожидаемый результат: major-теги 26 доступны для linux/amd64 и linux/arm64, а moving aliases base/build/run указывают на текущий baseline

## Пруфы
- node:26-slim manifest содержит linux/amd64 и linux/arm64
- docker run --rm --pull always node:26-slim node --version возвращает v26.1.0
- docker build --pull --build-arg node_image=node:26-slim --build-arg stack_id=tech.atlantislab.stacks.node stacks/node/base проходит локально
- actionlint .github/workflows/docker-release.yaml проходит локально
- ruby YAML.load_file для .github/workflows/docker-release.yaml проходит локально
