### PR TITLE
Fix yarn-workspace start-image launch command

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -197,16 +197,16 @@ jobs:
         include:
           - name: require-extension
             directory: buildpacks/require-extension
-            image: atlantislab/buildpack-require-extension:0.1.1
+            image-repository: atlantislab/buildpack-require-extension
           - name: yarn-install
             directory: buildpacks/yarn-install
-            image: atlantislab/buildpack-yarn-install:0.1.1
+            image-repository: atlantislab/buildpack-yarn-install
           - name: yarn-cache
             directory: buildpacks/yarn-cache
-            image: atlantislab/buildpack-yarn-cache:0.1.1
+            image-repository: atlantislab/buildpack-yarn-cache
           - name: yarn-workspace-start
             directory: buildpacks/yarn-workspace-start
-            image: atlantislab/buildpack-yarn-workspace-start:0.1.1
+            image-repository: atlantislab/buildpack-yarn-workspace-start
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -233,13 +233,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Publish ${{ matrix.image }}
+      - name: Resolve buildpack image
+        id: buildpack-image
         working-directory: ${{ matrix.directory }}
-        run: pack buildpack package ${{ matrix.image }} --config ./package.toml --target linux/amd64 --target linux/arm64 --publish
+        env:
+          IMAGE_REPOSITORY: ${{ matrix.image-repository }}
+        run: |
+          version="$(awk -F' *= *' '$1 == "version" { gsub(/"/, "", $2); print $2; exit }' buildpack.toml)"
+          [[ -n "${version}" ]]
+
+          echo "image=${IMAGE_REPOSITORY}:${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish ${{ steps.buildpack-image.outputs.image }}
+        working-directory: ${{ matrix.directory }}
+        run: pack buildpack package ${{ steps.buildpack-image.outputs.image }} --config ./package.toml --target linux/amd64 --target linux/arm64 --publish
 
       - name: Verify linux/amd64 and linux/arm64
         env:
-          IMAGE: ${{ matrix.image }}
+          IMAGE: ${{ steps.buildpack-image.outputs.image }}
         run: |
           docker buildx imagetools inspect "${IMAGE}" | tee manifest.txt
           grep -q linux/amd64 manifest.txt
@@ -266,13 +277,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Publish atlantislab/buildpack-yarn-workspace:0.1.1
+      - name: Resolve buildpack group image
+        id: buildpack-image
         working-directory: buildpacks/yarn-workspace
-        run: pack buildpack package atlantislab/buildpack-yarn-workspace:0.1.1 --config ./package.toml --target linux/amd64 --target linux/arm64 --publish
+        run: |
+          version="$(awk -F' *= *' '$1 == "version" { gsub(/"/, "", $2); print $2; exit }' buildpack.toml)"
+          [[ -n "${version}" ]]
+
+          echo "image=atlantislab/buildpack-yarn-workspace:${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish ${{ steps.buildpack-image.outputs.image }}
+        working-directory: buildpacks/yarn-workspace
+        run: pack buildpack package ${{ steps.buildpack-image.outputs.image }} --config ./package.toml --target linux/amd64 --target linux/arm64 --publish
 
       - name: Verify linux/amd64 and linux/arm64
         env:
-          IMAGE: atlantislab/buildpack-yarn-workspace:0.1.1
+          IMAGE: ${{ steps.buildpack-image.outputs.image }}
         run: |
           docker buildx imagetools inspect "${IMAGE}" | tee manifest.txt
           grep -q linux/amd64 manifest.txt

--- a/buildpacks/yarn-workspace-start/buildpack.toml
+++ b/buildpacks/yarn-workspace-start/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [buildpack]
 id = "tech.atlantislab.buildpacks.yarn-workspace-start"
-version = "0.1.1"
+version = "0.1.2"
 name = "Yarn Workspace Start Buildpack"
 
 [metadata]

--- a/buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.test.ts
+++ b/buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.test.ts
@@ -1,0 +1,113 @@
+/// <reference types="jest" />
+
+import { mkdtemp }                    from 'node:fs/promises'
+import { mkdir }                      from 'node:fs/promises'
+import { readFile }                   from 'node:fs/promises'
+import { rm }                         from 'node:fs/promises'
+import { writeFile }                  from 'node:fs/promises'
+import { tmpdir }                     from 'node:os'
+import { join }                       from 'node:path'
+
+import { BuildContext }               from '@atls/libcnb'
+import { Layers }                     from '@atls/libcnb'
+
+import { YarnWorkspaceStartBuilder }  from './yarn-workspace-start.builder'
+
+const writePackageJson = async (
+  applicationDir: string,
+  scripts: Record<string, string>
+): Promise<void> => {
+  await writeFile(
+    join(applicationDir, 'package.json'),
+    JSON.stringify({ scripts }, null, 2)
+  )
+}
+
+const createContext = async (): Promise<{
+  applicationDir: string
+  context: BuildContext
+  outputDir: string
+  rootDir: string
+  runScriptPath: string
+}> => {
+  const rootDir = await mkdtemp(join(tmpdir(), 'yarn-workspace-start-'))
+  const applicationDir = join(rootDir, 'workspace')
+  const layersDir = join(rootDir, 'layers')
+  const outputDir = join(rootDir, 'output')
+
+  await mkdir(applicationDir)
+  await mkdir(layersDir)
+  await mkdir(outputDir)
+
+  return {
+    applicationDir,
+    context: {
+      applicationDir,
+      layers: new Layers(layersDir),
+    } as BuildContext,
+    outputDir,
+    rootDir,
+    runScriptPath: join(rootDir, 'run.sh'),
+  }
+}
+
+describe('YarnWorkspaceStartBuilder', () => {
+  it('uses scripts.start-image as the launch command', async () => {
+    const { applicationDir, context, outputDir, rootDir, runScriptPath } = await createContext()
+
+    try {
+      await writePackageJson(applicationDir, {
+        'start-image': 'yarn start-image',
+      })
+      await writeFile(join(applicationDir, '.pnp.cjs'), '')
+      await writeFile(join(applicationDir, '.pnp.loader.mjs'), '')
+
+      const result = await new YarnWorkspaceStartBuilder(runScriptPath).build(context)
+      const runScript = await readFile(runScriptPath, 'utf-8')
+
+      await result.toPath(outputDir)
+
+      expect(runScript).toBe('#!/usr/bin/env bash\numask 0002\nyarn start-image')
+      expect(runScript).not.toContain('undefined')
+      expect(result.launchMetadata.processes[0].command).toEqual(['./run.sh'])
+      expect(result.layers).toHaveLength(1)
+      await expect(readFile(join(rootDir, 'layers/node-options/env.launch/NODE_OPTIONS.append'), 'utf-8'))
+        .resolves
+        .toBe(`--enable-source-maps --require ${join(applicationDir, '.pnp.cjs')} --loader ${join(applicationDir, '.pnp.loader.mjs')}`)
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  it('fails when scripts.start-image is missing', async () => {
+    const { applicationDir, context, rootDir, runScriptPath } = await createContext()
+
+    try {
+      await writePackageJson(applicationDir, {
+        start: 'yarn start',
+      })
+
+      await expect(new YarnWorkspaceStartBuilder(runScriptPath).build(context))
+        .rejects
+        .toThrow('Missing required package.json script "start-image" for launch command')
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  it('fails when scripts.start-image is empty', async () => {
+    const { applicationDir, context, rootDir, runScriptPath } = await createContext()
+
+    try {
+      await writePackageJson(applicationDir, {
+        'start-image': '   ',
+      })
+
+      await expect(new YarnWorkspaceStartBuilder(runScriptPath).build(context))
+        .rejects
+        .toThrow('Missing required package.json script "start-image" for launch command')
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.ts
+++ b/buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.ts
@@ -10,6 +10,7 @@ import { BuildResult }  from '@atls/libcnb'
 import { Process }      from '@atls/libcnb'
 
 const RUN_SCRIPT_PATH = '/workspace/run.sh'
+const START_IMAGE_SCRIPT = 'start-image'
 const PNP_CJS = '.pnp.cjs'
 const PNP_ESM_LOADER = '.pnp.loader.mjs'
 
@@ -24,13 +25,19 @@ const fileExists = async (path: string): Promise<boolean> => {
 }
 
 export class YarnWorkspaceStartBuilder implements Builder {
+  constructor(private readonly runScriptPath: string = RUN_SCRIPT_PATH) {}
+
   async build(ctx: BuildContext): Promise<BuildResult> {
     const pkgjson = JSON.parse(readFileSync(join(ctx.applicationDir, 'package.json'), 'utf-8'))
 
-    const command = pkgjson.scripts.start
+    const command = pkgjson.scripts?.[START_IMAGE_SCRIPT]
 
-    await writeFile(RUN_SCRIPT_PATH, `#!/usr/bin/env bash\numask 0002\n${command}`)
-    await chmod(RUN_SCRIPT_PATH, '755')
+    if (typeof command !== 'string' || command.trim().length === 0) {
+      throw new Error(`Missing required package.json script "${START_IMAGE_SCRIPT}" for launch command`)
+    }
+
+    await writeFile(this.runScriptPath, `#!/usr/bin/env bash\numask 0002\n${command}`)
+    await chmod(this.runScriptPath, '755')
 
     const nodeOptionsLayer = await ctx.layers.get('node-options', true, true, true)
 

--- a/buildpacks/yarn-workspace/buildpack.toml
+++ b/buildpacks/yarn-workspace/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [buildpack]
 id = "tech.atlantislab.buildpacks.yarn-workspace"
-version = "0.1.1"
+version = "0.1.2"
 name = "Yarn Workspace Buildpack"
 
 [metadata]
@@ -21,9 +21,8 @@ version = "0.1.1"
 
 [[order.group]]
 id = "tech.atlantislab.buildpacks.yarn-workspace-start"
-version = "0.1.1"
+version = "0.1.2"
 
 [[order.group]]
 id = "tech.atlantislab.buildpacks.require-extension"
 version = "0.1.1"
-

--- a/buildpacks/yarn-workspace/package.toml
+++ b/buildpacks/yarn-workspace/package.toml
@@ -11,4 +11,4 @@ uri = "docker://docker.io/atlantislab/buildpack-yarn-install:0.1.1"
 uri = "docker://docker.io/atlantislab/buildpack-yarn-cache:0.1.1"
 
 [[dependencies]]
-uri = "docker://docker.io/atlantislab/buildpack-yarn-workspace-start:0.1.1"
+uri = "docker://docker.io/atlantislab/buildpack-yarn-workspace-start:0.1.2"


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#56

## Как проверять
### До фикса
1. Контекст: buildpack `yarn-workspace-start` для package с `scripts.start-image` и без `scripts.start`
Действие: выполнить build и сгенерировать launch script
Ожидаемый результат: До фикса: `/workspace/run.sh` получает `undefined` вместо runtime-команды

### После фикса
1. Контекст: buildpack `yarn-workspace-start` для package с `scripts.start-image` и без `scripts.start`
Действие: выполнить build и сгенерировать launch script
Ожидаемый результат: После фикса: launch script содержит команду из `scripts.start-image`, build падает с явной ошибкой при пустом или отсутствующем `start-image`, PnP `NODE_OPTIONS` сохраняет `.pnp.cjs` и `.pnp.loader.mjs`

## Пруфы
- `yarn test unit --find-related-tests buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.ts buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.test.ts` passed
- `yarn typecheck buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.ts buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.test.ts` passed
- `yarn lint buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.ts buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.test.ts` passed
- `yarn workspace @atls/buildpack-yarn-workspace-start build` passed
- `git diff --check` passed
- `yarn checks release` did not run locally: checks plugin requires GitHub auth token (`Parameter token or opts.auth is required`)
