### PR TITLE
fix: package buildpacks from staged artifacts

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -244,9 +244,31 @@ jobs:
 
           echo "image=${IMAGE_REPOSITORY}:${version}" >> "${GITHUB_OUTPUT}"
 
+      - name: Prepare buildpack package
+        id: buildpack-package
+        env:
+          BUILDPACK_DIRECTORY: ${{ matrix.directory }}
+          BUILDPACK_NAME: ${{ matrix.name }}
+        run: |
+          package_config="${RUNNER_TEMP}/${BUILDPACK_NAME}-package.toml"
+          stage_dir="${RUNNER_TEMP}/${BUILDPACK_NAME}-buildpack"
+
+          ./scripts/prepare-buildpack-package.sh "${BUILDPACK_DIRECTORY}" "${stage_dir}" "${package_config}"
+
+          echo "config=${package_config}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify buildpack package content
+        env:
+          BUILDPACK_ARCHIVE: ${{ runner.temp }}/${{ matrix.name }}
+          BUILDPACK_DIRECTORY: ${{ matrix.directory }}
+          PACKAGE_CONFIG: ${{ steps.buildpack-package.outputs.config }}
+        run: |
+          pack buildpack package "${BUILDPACK_ARCHIVE}" --config "${PACKAGE_CONFIG}" --target linux/amd64 --target linux/arm64 --format file
+          ./scripts/verify-buildpack-package.sh "${BUILDPACK_ARCHIVE}-linux-amd64.cnb" "${BUILDPACK_DIRECTORY}"
+          ./scripts/verify-buildpack-package.sh "${BUILDPACK_ARCHIVE}-linux-arm64.cnb" "${BUILDPACK_DIRECTORY}"
+
       - name: Publish ${{ steps.buildpack-image.outputs.image }}
-        working-directory: ${{ matrix.directory }}
-        run: pack buildpack package ${{ steps.buildpack-image.outputs.image }} --config ./package.toml --target linux/amd64 --target linux/arm64 --publish
+        run: pack buildpack package ${{ steps.buildpack-image.outputs.image }} --config ${{ steps.buildpack-package.outputs.config }} --target linux/amd64 --target linux/arm64 --publish
 
       - name: Verify linux/amd64 and linux/arm64
         env:
@@ -286,9 +308,27 @@ jobs:
 
           echo "image=atlantislab/buildpack-yarn-workspace:${version}" >> "${GITHUB_OUTPUT}"
 
+      - name: Prepare buildpack package
+        id: buildpack-package
+        run: |
+          package_config="${RUNNER_TEMP}/yarn-workspace-package.toml"
+          stage_dir="${RUNNER_TEMP}/yarn-workspace-buildpack"
+
+          ./scripts/prepare-buildpack-package.sh buildpacks/yarn-workspace "${stage_dir}" "${package_config}"
+
+          echo "config=${package_config}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify buildpack package content
+        env:
+          BUILDPACK_ARCHIVE: ${{ runner.temp }}/yarn-workspace
+          PACKAGE_CONFIG: ${{ steps.buildpack-package.outputs.config }}
+        run: |
+          pack buildpack package "${BUILDPACK_ARCHIVE}" --config "${PACKAGE_CONFIG}" --target linux/amd64 --target linux/arm64 --format file
+          ./scripts/verify-buildpack-package.sh "${BUILDPACK_ARCHIVE}-linux-amd64.cnb" buildpacks/yarn-workspace
+          ./scripts/verify-buildpack-package.sh "${BUILDPACK_ARCHIVE}-linux-arm64.cnb" buildpacks/yarn-workspace
+
       - name: Publish ${{ steps.buildpack-image.outputs.image }}
-        working-directory: buildpacks/yarn-workspace
-        run: pack buildpack package ${{ steps.buildpack-image.outputs.image }} --config ./package.toml --target linux/amd64 --target linux/arm64 --publish
+        run: pack buildpack package ${{ steps.buildpack-image.outputs.image }} --config ${{ steps.buildpack-package.outputs.config }} --target linux/amd64 --target linux/arm64 --publish
 
       - name: Verify linux/amd64 and linux/arm64
         env:

--- a/buildpacks/require-extension/buildpack.toml
+++ b/buildpacks/require-extension/buildpack.toml
@@ -6,7 +6,7 @@ version = "0.1.1"
 name = "Extensions requirer"
 
 [metadata]
-include_files = ["bin/build", "bin/detect", "buildpack.toml"]
+include-files = ["bin/build", "bin/detect", "buildpack.toml"]
 
 [[targets]]
 os = "linux"

--- a/buildpacks/yarn-cache/buildpack.toml
+++ b/buildpacks/yarn-cache/buildpack.toml
@@ -2,12 +2,12 @@ api = "0.10"
 
 [buildpack]
 id = "tech.atlantislab.buildpacks.yarn-cache"
-version = "0.1.1"
+version = "0.1.2"
 name = "Yarn Workspace Pack Buildpack"
 
 [metadata]
-include_files = ["dist", "bin/build", "bin/detect", "buildpack.toml"]
-pre_package = "yarn build"
+include-files = ["dist", "bin/build", "bin/detect", "buildpack.toml"]
+pre-package = "yarn build"
 
 [[targets]]
 os = "linux"

--- a/buildpacks/yarn-install/buildpack.toml
+++ b/buildpacks/yarn-install/buildpack.toml
@@ -2,12 +2,12 @@ api = "0.10"
 
 [buildpack]
 id = "tech.atlantislab.buildpacks.yarn-install"
-version = "0.1.1"
+version = "0.1.2"
 name = "Yarn Install Buildpack"
 
 [metadata]
-include_files = ["dist", "bin/build", "bin/detect", "buildpack.toml"]
-pre_package = "yarn build"
+include-files = ["dist", "bin/build", "bin/detect", "buildpack.toml"]
+pre-package = "yarn build"
 
 [[targets]]
 os = "linux"

--- a/buildpacks/yarn-workspace-start/buildpack.toml
+++ b/buildpacks/yarn-workspace-start/buildpack.toml
@@ -2,12 +2,12 @@ api = "0.10"
 
 [buildpack]
 id = "tech.atlantislab.buildpacks.yarn-workspace-start"
-version = "0.1.2"
+version = "0.1.3"
 name = "Yarn Workspace Start Buildpack"
 
 [metadata]
-include_files = ["dist", "bin/build", "bin/detect", "buildpack.toml"]
-pre_package = "yarn build"
+include-files = ["dist", "bin/build", "bin/detect", "buildpack.toml"]
+pre-package = "yarn build"
 
 [[targets]]
 os = "linux"

--- a/buildpacks/yarn-workspace/buildpack.toml
+++ b/buildpacks/yarn-workspace/buildpack.toml
@@ -2,26 +2,26 @@ api = "0.10"
 
 [buildpack]
 id = "tech.atlantislab.buildpacks.yarn-workspace"
-version = "0.1.2"
+version = "0.1.3"
 name = "Yarn Workspace Buildpack"
 
 [metadata]
-include_files = ["buildpack.toml"]
+include-files = ["buildpack.toml"]
 
 [[order]]
 [[order.group]]
 id = "tech.atlantislab.buildpacks.yarn-install"
 optional = true
-version = "0.1.1"
+version = "0.1.2"
 
 [[order.group]]
 id = "tech.atlantislab.buildpacks.yarn-cache"
 optional = true
-version = "0.1.1"
+version = "0.1.2"
 
 [[order.group]]
 id = "tech.atlantislab.buildpacks.yarn-workspace-start"
-version = "0.1.2"
+version = "0.1.3"
 
 [[order.group]]
 id = "tech.atlantislab.buildpacks.require-extension"

--- a/buildpacks/yarn-workspace/package.toml
+++ b/buildpacks/yarn-workspace/package.toml
@@ -5,10 +5,10 @@ uri = "."
 uri = "docker://docker.io/atlantislab/buildpack-require-extension:0.1.1"
 
 [[dependencies]]
-uri = "docker://docker.io/atlantislab/buildpack-yarn-install:0.1.1"
+uri = "docker://docker.io/atlantislab/buildpack-yarn-install:0.1.2"
 
 [[dependencies]]
-uri = "docker://docker.io/atlantislab/buildpack-yarn-cache:0.1.1"
+uri = "docker://docker.io/atlantislab/buildpack-yarn-cache:0.1.2"
 
 [[dependencies]]
-uri = "docker://docker.io/atlantislab/buildpack-yarn-workspace-start:0.1.2"
+uri = "docker://docker.io/atlantislab/buildpack-yarn-workspace-start:0.1.3"

--- a/scripts/prepare-buildpack-package.sh
+++ b/scripts/prepare-buildpack-package.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 3 ]]; then
+  echo "usage: $0 <buildpack-dir> <stage-dir> <package-config>" >&2
+  exit 64
+fi
+
+source_dir="$1"
+stage_dir="$2"
+package_config="$3"
+
+if [[ ! -f "${source_dir}/buildpack.toml" || ! -f "${source_dir}/package.toml" ]]; then
+  echo "buildpack.toml and package.toml are required in ${source_dir}" >&2
+  exit 1
+fi
+
+source_dir="$(cd "${source_dir}" && pwd)"
+mkdir -p "$(dirname "${stage_dir}")" "$(dirname "${package_config}")"
+stage_parent="$(cd "$(dirname "${stage_dir}")" && pwd)"
+config_parent="$(cd "$(dirname "${package_config}")" && pwd)"
+stage_dir="${stage_parent}/$(basename "${stage_dir}")"
+package_config="${config_parent}/$(basename "${package_config}")"
+
+rm -rf "${stage_dir}"
+mkdir -p "${stage_dir}"
+
+cp "${source_dir}/buildpack.toml" "${stage_dir}/buildpack.toml"
+
+if [[ -d "${source_dir}/bin" ]]; then
+  cp -R "${source_dir}/bin" "${stage_dir}/bin"
+fi
+
+if [[ -d "${source_dir}/bin" ]] && grep -RqsF "../dist/index" "${source_dir}/bin"; then
+  (cd "${source_dir}" && yarn build)
+
+  if [[ ! -f "${source_dir}/dist/index.js" ]]; then
+    echo "expected ${source_dir}/dist/index.js after build" >&2
+    exit 1
+  fi
+
+  cp -R "${source_dir}/dist" "${stage_dir}/dist"
+fi
+
+awk -v uri="${stage_dir}" '
+  BEGIN {
+    in_buildpack = 0
+    replaced = 0
+  }
+
+  /^\[buildpack\]$/ {
+    in_buildpack = 1
+    print
+    next
+  }
+
+  /^\[/ {
+    in_buildpack = 0
+  }
+
+  in_buildpack && !replaced && /^uri[[:space:]]*=/ {
+    print "uri = \"" uri "\""
+    replaced = 1
+    next
+  }
+
+  {
+    print
+  }
+
+  END {
+    if (!replaced) {
+      exit 42
+    }
+  }
+' "${source_dir}/package.toml" > "${package_config}.tmp" || {
+  rm -f "${package_config}.tmp"
+  echo "failed to rewrite [buildpack] uri in ${source_dir}/package.toml" >&2
+  exit 1
+}
+
+mv "${package_config}.tmp" "${package_config}"

--- a/scripts/verify-buildpack-package.sh
+++ b/scripts/verify-buildpack-package.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "usage: $0 <buildpack-archive> <buildpack-dir>" >&2
+  exit 64
+fi
+
+archive="$1"
+source_dir="$2"
+
+if [[ ! -f "${archive}" ]]; then
+  echo "archive does not exist: ${archive}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${source_dir}/buildpack.toml" ]]; then
+  echo "buildpack.toml is required in ${source_dir}" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+oci_dir="${tmp_dir}/oci"
+root_dir="${tmp_dir}/root"
+mkdir -p "${oci_dir}" "${root_dir}"
+
+tar -xf "${archive}" -C "${oci_dir}"
+
+for blob in "${oci_dir}"/blobs/sha256/*; do
+  if tar -tf "${blob}" >/dev/null 2>&1; then
+    tar -xf "${blob}" -C "${root_dir}"
+  fi
+done
+
+buildpack_id="$(awk -F' *= *' '$1 == "id" { gsub(/"/, "", $2); print $2; exit }' "${source_dir}/buildpack.toml")"
+buildpack_version="$(awk -F' *= *' '$1 == "version" { gsub(/"/, "", $2); print $2; exit }' "${source_dir}/buildpack.toml")"
+
+if [[ -z "${buildpack_id}" || -z "${buildpack_version}" ]]; then
+  echo "failed to resolve buildpack id/version from ${source_dir}/buildpack.toml" >&2
+  exit 1
+fi
+
+buildpack_root="${root_dir}/cnb/buildpacks/${buildpack_id}/${buildpack_version}"
+
+if [[ ! -d "${buildpack_root}" ]]; then
+  echo "packaged buildpack root is missing: /cnb/buildpacks/${buildpack_id}/${buildpack_version}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${buildpack_root}/buildpack.toml" ]]; then
+  echo "packaged buildpack.toml is missing" >&2
+  exit 1
+fi
+
+if [[ -d "${source_dir}/bin" ]]; then
+  while IFS= read -r -d '' bin_file; do
+    relative_path="${bin_file#"${source_dir}/"}"
+
+    if [[ ! -f "${buildpack_root}/${relative_path}" ]]; then
+      echo "packaged ${relative_path} is missing" >&2
+      exit 1
+    fi
+  done < <(find "${source_dir}/bin" -type f -print0)
+fi
+
+if [[ -d "${source_dir}/bin" ]] && grep -RqsF "../dist/index" "${source_dir}/bin"; then
+  if [[ ! -f "${buildpack_root}/dist/index.js" ]]; then
+    echo "packaged dist/index.js is missing" >&2
+    exit 1
+  fi
+fi
+
+for unexpected_path in src package.json package.toml; do
+  if [[ -e "${buildpack_root}/${unexpected_path}" ]]; then
+    echo "unexpected packaged source artifact: ${unexpected_path}" >&2
+    exit 1
+  fi
+done
+
+echo "verified /cnb/buildpacks/${buildpack_id}/${buildpack_version}"


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#58

## Как проверять
### До фикса
1. Контекст: `Docker release` публикует TypeScript buildpack напрямую из исходной директории.
Действие: запустить packaging buildpack через `package.toml` исходного buildpack.
Ожидаемый результат: До фикса: в опубликованный buildpack попадает `src`, `package.json` и `package.toml`, но не попадает `dist/index.js`; `bin/detect` падает с `Cannot find module '../dist/index'`.

### После фикса
1. Контекст: `Docker release` готовит staged package перед publish.
Действие: запустить подготовку, file packaging и проверку содержимого buildpack.
Ожидаемый результат: После фикса: TypeScript buildpack содержит `bin/*` и `dist/index.js`, а `src`, `package.json` и `package.toml` не попадают в пакет.

## Пруфы
- `bash -n scripts/prepare-buildpack-package.sh scripts/verify-buildpack-package.sh` passed
- `git diff --check origin/master..HEAD` passed
- `actionlint .github/workflows/docker-release.yaml` passed
- `pack buildpack package` + `scripts/verify-buildpack-package.sh` passed for `buildpacks/yarn-install`, `buildpacks/yarn-cache`, `buildpacks/yarn-workspace-start` on `linux/amd64` and `linux/arm64`
