### PR TITLE
fix: bump builder lifecycle

### DIFF
--- a/builders/base/builder.toml
+++ b/builders/base/builder.toml
@@ -1,7 +1,7 @@
 [[order]]
 
 [lifecycle]
-version = "0.21.9"
+version = "0.21.12"
 
 [build]
 image = "atlantislab/stack-node:build"


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#61

## Как проверять
### До фикса
1. Контекст: Docker release job for `atlantislab/builder-base:26-491270157c4b`
Действие: выполнить Docker Scout scan для builder image
Ожидаемый результат: до фикса scan падает на critical CVE в `golang.org/x/crypto 0.50.0`, потому что builder содержит lifecycle `0.21.9`

### После фикса
1. Контекст: local builder smoke для `builders/base/builder.toml`
Действие: выполнить `pack builder create atlantislab/builder-base:lifecycle-0.21.12-local --config builders/base/builder.toml --pull-policy always --target linux/arm64`, затем `pack builder inspect atlantislab/builder-base:lifecycle-0.21.12-local --output json`
Ожидаемый результат: builder собирается локально, а inspect показывает lifecycle `0.21.12`

## Пруфы
- `pack builder create`
```bash
Successfully created builder image 'atlantislab/builder-base:lifecycle-0.21.12-local'
```

- `pack builder inspect`
```bash
0.21.12
```

- `git diff --check`
```bash
# no output
```
