### PR TITLE
[Feature] Migrate Docker release to GHCR

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -18,6 +18,8 @@ on:
       - 'yarn.lock'
 
 env:
+  IMAGE_PREFIX: ghcr.io/atls
+  REGISTRY: ghcr.io
   STACK_ID: tech.atlantislab.stacks.node
   PACK_VERSION: 0.40.4
   PLATFORMS: linux/amd64,linux/arm64
@@ -45,9 +47,12 @@ jobs:
         id: release-config
         run: |
           node_image="$(awk -F= '$1 == "ARG node_image" { print $2; exit }' stacks/node/base/Dockerfile)"
-          [[ "${node_image}" =~ ^node:([0-9]+)-slim$ ]]
+          if [[ ! "${node_image}" =~ (^|/)node:([0-9]+)-slim$ ]]; then
+            echo "::error::Unsupported node_image '${node_image}'. Expected an image ending with node:<major>-slim."
+            exit 1
+          fi
 
-          node_major="${BASH_REMATCH[1]}"
+          node_major="${BASH_REMATCH[2]}"
           release_tag="${node_major}-${GITHUB_SHA::12}"
 
           {
@@ -69,6 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -79,13 +85,14 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4.0.0
 
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish atlantislab/stack-node:base-${{ needs.validate-release.outputs.release-tag }}
+      - name: Publish ghcr.io/atls/stack-node:base-${{ needs.validate-release.outputs.release-tag }}
         uses: docker/build-push-action@v7.1.0
         with:
           context: stacks/node/base
@@ -95,7 +102,7 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
           pull: true
           push: true
-          tags: atlantislab/stack-node:base-${{ needs.validate-release.outputs.release-tag }}
+          tags: ${{ env.IMAGE_PREFIX }}/stack-node:base-${{ needs.validate-release.outputs.release-tag }}
 
   build-stack:
     name: Build stack ${{ matrix.tag }}-${{ needs.validate-release.outputs.node-major }}
@@ -105,6 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -123,21 +131,22 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4.0.0
 
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish atlantislab/stack-node:${{ matrix.tag }}-${{ needs.validate-release.outputs.release-tag }}
+      - name: Publish ghcr.io/atls/stack-node:${{ matrix.tag }}-${{ needs.validate-release.outputs.release-tag }}
         uses: docker/build-push-action@v7.1.0
         with:
           context: ${{ matrix.context }}
-          build-args: base_image=atlantislab/stack-node:base-${{ needs.validate-release.outputs.release-tag }}
+          build-args: base_image=${{ env.IMAGE_PREFIX }}/stack-node:base-${{ needs.validate-release.outputs.release-tag }}
           platforms: ${{ env.PLATFORMS }}
           pull: true
           push: true
-          tags: atlantislab/stack-node:${{ matrix.tag }}-${{ needs.validate-release.outputs.release-tag }}
+          tags: ${{ env.IMAGE_PREFIX }}/stack-node:${{ matrix.tag }}-${{ needs.validate-release.outputs.release-tag }}
 
   publish-extensions:
     name: Publish extension ${{ matrix.name }}
@@ -145,19 +154,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: curl
             directory: extensions/curl
-            image: atlantislab/buildpack-extension-curl:0.0.1
+            image: ghcr.io/atls/buildpack-extension-curl:0.0.1
           - name: htop
             directory: extensions/htop
-            image: atlantislab/buildpack-extension-htop:0.0.1
+            image: ghcr.io/atls/buildpack-extension-htop:0.0.1
           - name: graphql-hive
             directory: extensions/graphql-hive
-            image: atlantislab/buildpack-extension-graphql-hive:0.0.1
+            image: ghcr.io/atls/buildpack-extension-graphql-hive:0.0.1
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -167,11 +177,12 @@ jobs:
         with:
           pack-version: ${{ env.PACK_VERSION }}
 
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish ${{ matrix.image }}
         working-directory: ${{ matrix.directory }}
@@ -191,22 +202,23 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: require-extension
             directory: buildpacks/require-extension
-            image-repository: atlantislab/buildpack-require-extension
+            image-repository: ghcr.io/atls/buildpack-require-extension
           - name: yarn-install
             directory: buildpacks/yarn-install
-            image-repository: atlantislab/buildpack-yarn-install
+            image-repository: ghcr.io/atls/buildpack-yarn-install
           - name: yarn-cache
             directory: buildpacks/yarn-cache
-            image-repository: atlantislab/buildpack-yarn-cache
+            image-repository: ghcr.io/atls/buildpack-yarn-cache
           - name: yarn-workspace-start
             directory: buildpacks/yarn-workspace-start
-            image-repository: atlantislab/buildpack-yarn-workspace-start
+            image-repository: ghcr.io/atls/buildpack-yarn-workspace-start
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -227,11 +239,12 @@ jobs:
         with:
           pack-version: ${{ env.PACK_VERSION }}
 
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Resolve buildpack image
         id: buildpack-image
@@ -263,12 +276,12 @@ jobs:
           BUILDPACK_DIRECTORY: ${{ matrix.directory }}
           PACKAGE_CONFIG: ${{ steps.buildpack-package.outputs.config }}
         run: |
-          pack buildpack package "${BUILDPACK_ARCHIVE}" --config "${PACKAGE_CONFIG}" --target linux/amd64 --target linux/arm64 --format file
+          pack buildpack package "${BUILDPACK_ARCHIVE}" --config "${PACKAGE_CONFIG}" --target linux/amd64 --target linux/arm64 --format file --pull-policy if-not-present
           ./scripts/verify-buildpack-package.sh "${BUILDPACK_ARCHIVE}-linux-amd64.cnb" "${BUILDPACK_DIRECTORY}"
           ./scripts/verify-buildpack-package.sh "${BUILDPACK_ARCHIVE}-linux-arm64.cnb" "${BUILDPACK_DIRECTORY}"
 
       - name: Publish ${{ steps.buildpack-image.outputs.image }}
-        run: pack buildpack package ${{ steps.buildpack-image.outputs.image }} --config ${{ steps.buildpack-package.outputs.config }} --target linux/amd64 --target linux/arm64 --publish
+        run: pack buildpack package ${{ steps.buildpack-image.outputs.image }} --config ${{ steps.buildpack-package.outputs.config }} --target linux/amd64 --target linux/arm64 --publish --pull-policy if-not-present
 
       - name: Verify linux/amd64 and linux/arm64
         env:
@@ -284,6 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -293,20 +307,23 @@ jobs:
         with:
           pack-version: ${{ env.PACK_VERSION }}
 
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Resolve buildpack group image
         id: buildpack-image
         working-directory: buildpacks/yarn-workspace
+        env:
+          IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}
         run: |
           version="$(awk -F' *= *' '$1 == "version" { gsub(/"/, "", $2); print $2; exit }' buildpack.toml)"
           [[ -n "${version}" ]]
 
-          echo "image=atlantislab/buildpack-yarn-workspace:${version}" >> "${GITHUB_OUTPUT}"
+          echo "image=${IMAGE_PREFIX}/buildpack-yarn-workspace:${version}" >> "${GITHUB_OUTPUT}"
 
       - name: Prepare buildpack package
         id: buildpack-package
@@ -323,12 +340,12 @@ jobs:
           BUILDPACK_ARCHIVE: ${{ runner.temp }}/yarn-workspace
           PACKAGE_CONFIG: ${{ steps.buildpack-package.outputs.config }}
         run: |
-          pack buildpack package "${BUILDPACK_ARCHIVE}" --config "${PACKAGE_CONFIG}" --target linux/amd64 --target linux/arm64 --format file
+          pack buildpack package "${BUILDPACK_ARCHIVE}" --config "${PACKAGE_CONFIG}" --target linux/amd64 --target linux/arm64 --format file --pull-policy if-not-present
           ./scripts/verify-buildpack-package.sh "${BUILDPACK_ARCHIVE}-linux-amd64.cnb" buildpacks/yarn-workspace
           ./scripts/verify-buildpack-package.sh "${BUILDPACK_ARCHIVE}-linux-arm64.cnb" buildpacks/yarn-workspace
 
       - name: Publish ${{ steps.buildpack-image.outputs.image }}
-        run: pack buildpack package ${{ steps.buildpack-image.outputs.image }} --config ${{ steps.buildpack-package.outputs.config }} --target linux/amd64 --target linux/arm64 --publish
+        run: pack buildpack package ${{ steps.buildpack-image.outputs.image }} --config ${{ steps.buildpack-package.outputs.config }} --target linux/amd64 --target linux/arm64 --publish --pull-policy if-not-present
 
       - name: Verify linux/amd64 and linux/arm64
         env:
@@ -346,15 +363,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Verify linux/amd64 and linux/arm64
         env:
+          IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}
           RELEASE_TAG: ${{ needs.validate-release.outputs.release-tag }}
         run: |
           images=(
-            "atlantislab/stack-node:base-${RELEASE_TAG}"
-            "atlantislab/stack-node:build-${RELEASE_TAG}"
-            "atlantislab/stack-node:run-${RELEASE_TAG}"
+            "${IMAGE_PREFIX}/stack-node:base-${RELEASE_TAG}"
+            "${IMAGE_PREFIX}/stack-node:build-${RELEASE_TAG}"
+            "${IMAGE_PREFIX}/stack-node:run-${RELEASE_TAG}"
           )
 
           for image in "${images[@]}"; do
@@ -374,6 +400,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -383,25 +410,27 @@ jobs:
         with:
           pack-version: ${{ env.PACK_VERSION }}
 
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish builder
         env:
+          IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}
           RELEASE_TAG: ${{ needs.validate-release.outputs.release-tag }}
         run: |
           builder_config="${RUNNER_TEMP}/builder.toml"
           cp builders/base/builder.toml "${builder_config}"
 
           sed -i \
-            -e "s#atlantislab/stack-node:build#atlantislab/stack-node:build-${RELEASE_TAG}#g" \
-            -e "s#atlantislab/stack-node:run#atlantislab/stack-node:run-${RELEASE_TAG}#g" \
+            -e "s#${IMAGE_PREFIX}/stack-node:build#${IMAGE_PREFIX}/stack-node:build-${RELEASE_TAG}#g" \
+            -e "s#${IMAGE_PREFIX}/stack-node:run#${IMAGE_PREFIX}/stack-node:run-${RELEASE_TAG}#g" \
             "${builder_config}"
 
-          pack builder create "atlantislab/builder-base:${RELEASE_TAG}" --verbose --config "${builder_config}" --publish
+          pack builder create "${IMAGE_PREFIX}/builder-base:${RELEASE_TAG}" --verbose --config "${builder_config}" --publish --pull-policy if-not-present
 
   verify-builder-manifest:
     name: Verify builder manifest
@@ -411,12 +440,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Verify linux/amd64 and linux/arm64
         env:
+          IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}
           RELEASE_TAG: ${{ needs.validate-release.outputs.release-tag }}
         run: |
-          docker buildx imagetools inspect "atlantislab/builder-base:${RELEASE_TAG}" | tee manifest.txt
+          docker buildx imagetools inspect "${IMAGE_PREFIX}/builder-base:${RELEASE_TAG}" | tee manifest.txt
           grep -q linux/amd64 manifest.txt
           grep -q linux/arm64 manifest.txt
 
@@ -428,6 +466,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -452,12 +491,19 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v4.0.0
 
+      - name: Login to GHCR
+        uses: docker/login-action@v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Verify Node.js major
         env:
           COMMAND: ${{ matrix.command }}
           ENTRYPOINT: ${{ matrix.entrypoint }}
           EXPECTED_NODE_MAJOR: ${{ needs.validate-release.outputs.node-major }}
-          IMAGE: atlantislab/stack-node:${{ matrix.tag }}-${{ needs.validate-release.outputs.node-major }}
+          IMAGE: ${{ env.IMAGE_PREFIX }}/stack-node:${{ matrix.tag }}-${{ needs.validate-release.outputs.node-major }}
           PLATFORM: ${{ matrix.platform }}
         run: |
           read -r -a command <<< "${COMMAND}"
@@ -476,6 +522,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -486,12 +533,20 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v4.0.0
 
+      - name: Login to GHCR
+        uses: docker/login-action@v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Verify Node.js major
         env:
           BUILDER_TAG: ${{ needs.validate-release.outputs.builder-tag }}
           EXPECTED_NODE_MAJOR: ${{ needs.validate-release.outputs.node-major }}
+          IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}
           PLATFORM: ${{ matrix.platform }}
-        run: docker run --rm --pull always --platform "${PLATFORM}" --entrypoint node "atlantislab/builder-base:${BUILDER_TAG}" --version | grep "^v${EXPECTED_NODE_MAJOR}\\."
+        run: docker run --rm --pull always --platform "${PLATFORM}" --entrypoint node "${IMAGE_PREFIX}/builder-base:${BUILDER_TAG}" --version | grep "^v${EXPECTED_NODE_MAJOR}\\."
 
   scan-release-images:
     name: Scan ${{ matrix.image }} ${{ matrix.platform }}
@@ -502,6 +557,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -509,16 +565,17 @@ jobs:
           - linux/amd64
           - linux/arm64
         image:
-          - atlantislab/builder-base:${{ needs.validate-release.outputs.release-tag }}
-          - atlantislab/stack-node:base-${{ needs.validate-release.outputs.release-tag }}
-          - atlantislab/stack-node:build-${{ needs.validate-release.outputs.release-tag }}
-          - atlantislab/stack-node:run-${{ needs.validate-release.outputs.release-tag }}
+          - ghcr.io/atls/builder-base:${{ needs.validate-release.outputs.release-tag }}
+          - ghcr.io/atls/stack-node:base-${{ needs.validate-release.outputs.release-tag }}
+          - ghcr.io/atls/stack-node:build-${{ needs.validate-release.outputs.release-tag }}
+          - ghcr.io/atls/stack-node:run-${{ needs.validate-release.outputs.release-tag }}
     steps:
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Report high and medium fixed vulnerabilities
         uses: docker/scout-action@v1.20.4
@@ -550,37 +607,40 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4.0.0
 
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Promote stack and builder tags
         env:
           BUILDER_TAG: ${{ needs.validate-release.outputs.builder-tag }}
+          IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}
           NODE_MAJOR: ${{ needs.validate-release.outputs.node-major }}
           RELEASE_TAG: ${{ needs.validate-release.outputs.release-tag }}
         run: |
           docker buildx imagetools create \
-            --tag "atlantislab/stack-node:base-${NODE_MAJOR}" \
-            --tag "atlantislab/stack-node:base" \
-            "atlantislab/stack-node:base-${RELEASE_TAG}"
+            --tag "${IMAGE_PREFIX}/stack-node:base-${NODE_MAJOR}" \
+            --tag "${IMAGE_PREFIX}/stack-node:base" \
+            "${IMAGE_PREFIX}/stack-node:base-${RELEASE_TAG}"
 
           docker buildx imagetools create \
-            --tag "atlantislab/stack-node:build-${NODE_MAJOR}" \
-            --tag "atlantislab/stack-node:build" \
-            "atlantislab/stack-node:build-${RELEASE_TAG}"
+            --tag "${IMAGE_PREFIX}/stack-node:build-${NODE_MAJOR}" \
+            --tag "${IMAGE_PREFIX}/stack-node:build" \
+            "${IMAGE_PREFIX}/stack-node:build-${RELEASE_TAG}"
 
           docker buildx imagetools create \
-            --tag "atlantislab/stack-node:run-${NODE_MAJOR}" \
-            --tag "atlantislab/stack-node:run" \
-            "atlantislab/stack-node:run-${RELEASE_TAG}"
+            --tag "${IMAGE_PREFIX}/stack-node:run-${NODE_MAJOR}" \
+            --tag "${IMAGE_PREFIX}/stack-node:run" \
+            "${IMAGE_PREFIX}/stack-node:run-${RELEASE_TAG}"
 
           docker buildx imagetools create \
-            --tag "atlantislab/builder-base:${BUILDER_TAG}" \
-            "atlantislab/builder-base:${RELEASE_TAG}"
+            --tag "${IMAGE_PREFIX}/builder-base:${BUILDER_TAG}" \
+            "${IMAGE_PREFIX}/builder-base:${RELEASE_TAG}"

--- a/README.md
+++ b/README.md
@@ -7,21 +7,21 @@
 Текущий production baseline берётся из `ARG node_image` в `stacks/node/base/Dockerfile`.
 
 Docker-релиз выполняется через GitHub Actions workflow `Docker release` после merge в `master`.
-Для публикации workflow использует Docker Hub secrets `DOCKERHUB_USERNAME` и `DOCKERHUB_TOKEN`.
+Для публикации workflow использует `GITHUB_TOKEN` с доступом `packages: write` и публикует образы в GitHub Container Registry.
 
 1. В `stacks/node/base/Dockerfile` обновить `ARG node_image`.
 2. Вмержить PR с релизными изменениями в `master`.
 3. Дождаться прохождения workflow `Docker release`.
-4. Проверить наличие нового тега в [Docker Hub](https://hub.docker.com/r/atlantislab/builder-base/tags).
+4. Проверить наличие нового тега в [GHCR](https://github.com/orgs/atls/packages/container/package/builder-base).
 
 Workflow публикует:
 
-1. `atlantislab/stack-node:base-<Node major>`
-2. `atlantislab/stack-node:build-<Node major>`
-3. `atlantislab/stack-node:run-<Node major>`
-4. `atlantislab/stack-node:base`, `atlantislab/stack-node:build`, `atlantislab/stack-node:run` как moving aliases текущего baseline
-5. `atlantislab/buildpack-*`
-6. `atlantislab/builder-base:<Node major>`, собранный из stack tags того же Node major
+1. `ghcr.io/atls/stack-node:base-<Node major>`
+2. `ghcr.io/atls/stack-node:build-<Node major>`
+3. `ghcr.io/atls/stack-node:run-<Node major>`
+4. `ghcr.io/atls/stack-node:base`, `ghcr.io/atls/stack-node:build`, `ghcr.io/atls/stack-node:run` как moving aliases текущего baseline
+5. `ghcr.io/atls/buildpack-*`
+6. `ghcr.io/atls/builder-base:<Node major>`, собранный из stack tags того же Node major
 
 ## Runtime запуск Yarn PnP ESM workspace
 

--- a/builders/base/builder.toml
+++ b/builders/base/builder.toml
@@ -4,11 +4,11 @@
 version = "0.21.12"
 
 [build]
-image = "atlantislab/stack-node:build"
+image = "ghcr.io/atls/stack-node:build"
 
 [run]
 [[run.images]]
-image = "atlantislab/stack-node:run"
+image = "ghcr.io/atls/stack-node:run"
 
 [[targets]]
 os = "linux"
@@ -20,15 +20,15 @@ arch = "arm64"
 
 [[extensions]]
 id = "tech.atlantislab.extensions.curl"
-uri = "docker://docker.io/atlantislab/buildpack-extension-curl:0.0.1"
+uri = "docker://ghcr.io/atls/buildpack-extension-curl:0.0.1"
 
 [[extensions]]
 id = "tech.atlantislab.extensions.htop"
-uri = "docker://docker.io/atlantislab/buildpack-extension-htop:0.0.1"
+uri = "docker://ghcr.io/atls/buildpack-extension-htop:0.0.1"
 
 [[extensions]]
 id = "tech.atlantislab.extensions.graphql-hive"
-uri = "docker://docker.io/atlantislab/buildpack-extension-graphql-hive:0.0.1"
+uri = "docker://ghcr.io/atls/buildpack-extension-graphql-hive:0.0.1"
 
 [[order-extensions]]
 [[order-extensions.group]]
@@ -43,5 +43,5 @@ id = "tech.atlantislab.extensions.graphql-hive"
 # Deprecated
 [stack]
 id = "tech.atlantislab.stacks.node"
-run-image = "atlantislab/stack-node:run"
-build-image = "atlantislab/stack-node:build"
+run-image = "ghcr.io/atls/stack-node:run"
+build-image = "ghcr.io/atls/stack-node:build"

--- a/buildpacks/yarn-workspace/package.toml
+++ b/buildpacks/yarn-workspace/package.toml
@@ -2,13 +2,13 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://docker.io/atlantislab/buildpack-require-extension:0.1.1"
+uri = "docker://ghcr.io/atls/buildpack-require-extension:0.1.1"
 
 [[dependencies]]
-uri = "docker://docker.io/atlantislab/buildpack-yarn-install:0.1.2"
+uri = "docker://ghcr.io/atls/buildpack-yarn-install:0.1.2"
 
 [[dependencies]]
-uri = "docker://docker.io/atlantislab/buildpack-yarn-cache:0.1.2"
+uri = "docker://ghcr.io/atls/buildpack-yarn-cache:0.1.2"
 
 [[dependencies]]
-uri = "docker://docker.io/atlantislab/buildpack-yarn-workspace-start:0.1.3"
+uri = "docker://ghcr.io/atls/buildpack-yarn-workspace-start:0.1.3"

--- a/stacks/node/base/Dockerfile
+++ b/stacks/node/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG node_image=node:26-slim
+ARG node_image=public.ecr.aws/docker/library/node:26-slim
 FROM ${node_image}
 
 ARG cnb_uid=1001


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#63

## Как проверять
### Основной сценарий
1. Контекст: `Docker release` после merge в `master`.
Действие: workflow собирает stack, extensions, buildpack components, composite buildpack, builder, scan и promote.
Ожидаемый результат: publish/verify/promote используют `ghcr.io/atls/...`, логинятся через `GITHUB_TOKEN`, а upstream Node base берётся из `public.ecr.aws/docker/library/node:26-slim`.

### Дополнительный сценарий
1. Контекст: buildpack component packaging до публикации composite buildpack.
Действие: `prepare-buildpack-package.sh`, `pack buildpack package --format file` и `verify-buildpack-package.sh` для publishable components.
Ожидаемый результат: `.cnb` содержит ожидаемый `dist/index.js` для detect/build scripts на `linux/amd64` и `linux/arm64`.

## Пруфы
- `actionlint .github/workflows/docker-release.yaml` passed
- `git diff --check` passed
- `docker run --rm --pull always public.ecr.aws/docker/library/node:26-slim node --version` -> `v26.3.0`
- `bash` release regex resolves `node_major=26` from `public.ecr.aws/docker/library/node:26-slim`
- `yarn workspaces foreach --all --topological-dev run build` passed
- component package/verify loop passed for `require-extension`, `yarn-install`, `yarn-cache`, `yarn-workspace-start` on `linux/amd64` and `linux/arm64`

Composite `buildpack-yarn-workspace` full registry pull-test is expected in the release workflow after the GHCR component images are published by the same workflow.
