### PR TITLE
fix(yarn-workspace-start): run image script through yarn

### DIFF
--- a/buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.test.ts
+++ b/buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.test.ts
@@ -52,13 +52,17 @@ const createContext = async (): Promise<{
 }
 
 describe('YarnWorkspaceStartBuilder', () => {
-  it('uses scripts.start-image as the launch command', async () => {
+  it('uses the packaged Yarn release to run scripts.start-image', async () => {
     const { applicationDir, context, outputDir, rootDir, runScriptPath } = await createContext()
 
     try {
       await writePackageJson(applicationDir, {
-        'start-image': 'yarn start-image',
+        'start-image': 'astro preview --host 0.0.0.0 --port 3000',
       })
+      await mkdir(join(applicationDir, '.yarn'))
+      await mkdir(join(applicationDir, '.yarn/releases'))
+      await writeFile(join(applicationDir, '.yarnrc.yml'), 'yarnPath: .yarn/releases/yarn.mjs\n')
+      await writeFile(join(applicationDir, '.yarn/releases/yarn.mjs'), '')
       await writeFile(join(applicationDir, '.pnp.cjs'), '')
       await writeFile(join(applicationDir, '.pnp.loader.mjs'), '')
 
@@ -67,13 +71,33 @@ describe('YarnWorkspaceStartBuilder', () => {
 
       await result.toPath(outputDir)
 
-      expect(runScript).toBe('#!/usr/bin/env bash\numask 0002\nyarn start-image')
+      expect(runScript).toBe(
+        `#!/usr/bin/env bash\numask 0002\nexec node '${join(applicationDir, '.yarn/releases/yarn.mjs')}' start-image`
+      )
       expect(runScript).not.toContain('undefined')
       expect(result.launchMetadata.processes[0].command).toEqual(['./run.sh'])
       expect(result.layers).toHaveLength(1)
       await expect(readFile(join(rootDir, 'layers/node-options/env.launch/NODE_OPTIONS.append'), 'utf-8'))
         .resolves
         .toBe(`--enable-source-maps --require ${join(applicationDir, '.pnp.cjs')} --loader ${join(applicationDir, '.pnp.loader.mjs')}`)
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to global Yarn when no packaged Yarn release exists', async () => {
+    const { applicationDir, context, rootDir, runScriptPath } = await createContext()
+
+    try {
+      await writePackageJson(applicationDir, {
+        'start-image': 'node server.js',
+      })
+
+      await new YarnWorkspaceStartBuilder(runScriptPath).build(context)
+
+      await expect(readFile(runScriptPath, 'utf-8'))
+        .resolves
+        .toBe('#!/usr/bin/env bash\numask 0002\nexec yarn start-image')
     } finally {
       await rm(rootDir, { recursive: true, force: true })
     }

--- a/buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.ts
+++ b/buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { writeFile }    from 'node:fs/promises'
 import { chmod }        from 'node:fs/promises'
 import { join }         from 'node:path'
+import { isAbsolute }   from 'node:path'
 import { access }         from 'node:fs/promises'
 
 import { Builder }      from '@atls/libcnb'
@@ -13,6 +14,7 @@ const RUN_SCRIPT_PATH = '/workspace/run.sh'
 const START_IMAGE_SCRIPT = 'start-image'
 const PNP_CJS = '.pnp.cjs'
 const PNP_ESM_LOADER = '.pnp.loader.mjs'
+const YARN_RC = '.yarnrc.yml'
 
 const fileExists = async (path: string): Promise<boolean> => {
   try {
@@ -22,6 +24,46 @@ const fileExists = async (path: string): Promise<boolean> => {
   } catch {
     return false
   }
+}
+
+const shellQuote = (value: string): string => `'${value.replace(/'/g, `'\\''`)}'`
+
+const parseYarnPath = (content: string): string | undefined => {
+  const match = content.match(/^\s*yarnPath:\s*(.+?)\s*$/m)
+
+  return match?.[1]?.replace(/^['"]|['"]$/g, '')
+}
+
+const resolveYarnPath = async (applicationDir: string): Promise<string | undefined> => {
+  const yarnRcPath = join(applicationDir, YARN_RC)
+
+  if (!(await fileExists(yarnRcPath))) {
+    return undefined
+  }
+
+  const yarnPath = parseYarnPath(readFileSync(yarnRcPath, 'utf-8'))
+
+  if (!yarnPath) {
+    return undefined
+  }
+
+  const resolvedPath = isAbsolute(yarnPath) ? yarnPath : join(applicationDir, yarnPath)
+
+  if (!(await fileExists(resolvedPath))) {
+    return undefined
+  }
+
+  return resolvedPath
+}
+
+const resolveLaunchCommand = async (applicationDir: string): Promise<string> => {
+  const yarnPath = await resolveYarnPath(applicationDir)
+
+  if (yarnPath) {
+    return `exec node ${shellQuote(yarnPath)} ${START_IMAGE_SCRIPT}`
+  }
+
+  return `exec yarn ${START_IMAGE_SCRIPT}`
 }
 
 export class YarnWorkspaceStartBuilder implements Builder {
@@ -36,7 +78,10 @@ export class YarnWorkspaceStartBuilder implements Builder {
       throw new Error(`Missing required package.json script "${START_IMAGE_SCRIPT}" for launch command`)
     }
 
-    await writeFile(this.runScriptPath, `#!/usr/bin/env bash\numask 0002\n${command}`)
+    await writeFile(
+      this.runScriptPath,
+      `#!/usr/bin/env bash\numask 0002\n${await resolveLaunchCommand(ctx.applicationDir)}`
+    )
     await chmod(this.runScriptPath, '755')
 
     const nodeOptionsLayer = await ctx.layers.get('node-options', true, true, true)


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#65

## Как проверять
### До фикса
1. Контекст: `buildpack-yarn-workspace-start` builds launch metadata for a workspace with `scripts.start-image: astro preview --host 0.0.0.0 --port 3000` or `strapi start`.
Действие: inspect generated `/workspace/run.sh`.
Ожидаемый результат: `run.sh` contains the raw script body, so package binaries are looked up by plain shell and fail in PnP images without `node_modules`.

### После фикса
1. Контекст: the application image contains `.yarnrc.yml` with `yarnPath` and the referenced Yarn release.
Действие: inspect generated `/workspace/run.sh`.
Ожидаемый результат: `run.sh` executes `node <yarnPath> start-image`, so package script/bin resolution stays owned by Yarn.

2. Контекст: the application image has no packaged Yarn release.
Действие: inspect generated `/workspace/run.sh`.
Ожидаемый результат: `run.sh` falls back to `yarn start-image`.

## Пруфы
- `yarn test unit buildpacks/yarn-workspace-start/src/yarn-workspace-start.builder.test.ts`
```text
4 passed
```
- `yarn workspace @atls/buildpack-yarn-workspace-start build`
```text
completed
```
- `git diff --check`
```text
passed
```
