### PR TITLE
[Bug] Authenticate Docker Scout scans

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -577,6 +577,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Scout
+        uses: docker/login-action@v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Report high and medium fixed vulnerabilities
         uses: docker/scout-action@v1.20.4
         with:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 Docker-релиз выполняется через GitHub Actions workflow `Docker release` после merge в `master`.
 Для публикации workflow использует `GITHUB_TOKEN` с доступом `packages: write` и публикует образы в GitHub Container Registry.
+Для Docker Scout scan workflow использует `DOCKERHUB_USERNAME` и `DOCKERHUB_TOKEN` только как Docker Scout credentials.
 
 1. В `stacks/node/base/Dockerfile` обновить `ARG node_image`.
 2. Вмержить PR с релизными изменениями в `master`.


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#67

## Как проверять
### Основной сценарий
1. Контекст: `Docker release` после публикации GHCR images.
Действие: `scan-release-images` логинится в GHCR для чтения образов и отдельно логинится в Docker Hub credentials для Docker Scout entitlement.
Ожидаемый результат: `docker/scout-action` не запускается как `githubactions` и не падает на `not entitled to use Docker Scout`.

### Дополнительный сценарий
1. Контекст: release publishing после перехода на GHCR.
Действие: workflow публикует stack/buildpack/builder images.
Ожидаемый результат: publish/pull наших release images остаётся на `ghcr.io/atls/...`; Docker Hub credentials используются только для Scout scan auth.

## Пруфы
- `actionlint .github/workflows/docker-release.yaml` passed
- `git diff --check` passed
- Поиск старых Docker Hub release refs не нашёл `atlantislab/stack-node`, `atlantislab/builder-base`, `docker.io/atlantislab`.
- Падение post-merge run: https://github.com/atls/buildpacks/actions/runs/27575411635
```bash
could not authenticate: user githubactions not entitled to use Docker Scout
```
