### PR TITLE
[Bug] Build Node stack without official Node image

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -35,8 +35,8 @@ jobs:
     permissions:
       contents: read
     outputs:
+      base-image: ${{ steps.release-config.outputs.base-image }}
       builder-tag: ${{ steps.release-config.outputs.builder-tag }}
-      node-image: ${{ steps.release-config.outputs.node-image }}
       node-major: ${{ steps.release-config.outputs.node-major }}
       release-tag: ${{ steps.release-config.outputs.release-tag }}
     steps:
@@ -46,27 +46,28 @@ jobs:
       - name: Resolve release configuration
         id: release-config
         run: |
-          node_image="$(awk -F= '$1 == "ARG node_image" { print $2; exit }' stacks/node/base/Dockerfile)"
-          if [[ ! "${node_image}" =~ (^|/)node:([0-9]+)-slim$ ]]; then
-            echo "::error::Unsupported node_image '${node_image}'. Expected an image ending with node:<major>-slim."
+          base_image="$(awk -F= '$1 == "ARG base_image" { print $2; exit }' stacks/node/base/Dockerfile)"
+          node_version="$(awk -F= '$1 == "ARG node_version" { print $2; exit }' stacks/node/base/Dockerfile)"
+          if [[ ! "${node_version}" =~ ^([0-9]+)$ ]]; then
+            echo "::error::Unsupported node_version '${node_version}'. Expected a Node.js major version."
             exit 1
           fi
+          [[ -n "${base_image}" ]]
 
-          node_major="${BASH_REMATCH[2]}"
+          node_major="${BASH_REMATCH[1]}"
           release_tag="${node_major}-${GITHUB_SHA::12}"
 
           {
+            echo "base-image=${base_image}"
             echo "builder-tag=${node_major}"
-            echo "node-image=${node_image}"
             echo "node-major=${node_major}"
             echo "release-tag=${release_tag}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Verify Node.js major before publishing
+      - name: Verify base image manifest before publishing
         env:
-          NODE_IMAGE: ${{ steps.release-config.outputs.node-image }}
-          NODE_MAJOR: ${{ steps.release-config.outputs.node-major }}
-        run: docker run --rm --pull always "${NODE_IMAGE}" node --version | grep "^v${NODE_MAJOR}\\."
+          BASE_IMAGE: ${{ steps.release-config.outputs.base-image }}
+        run: docker buildx imagetools inspect "${BASE_IMAGE}" > /dev/null
 
   build-stack-base:
     name: Build stack base
@@ -97,7 +98,8 @@ jobs:
         with:
           context: stacks/node/base
           build-args: |
-            node_image=${{ needs.validate-release.outputs.node-image }}
+            base_image=${{ needs.validate-release.outputs.base-image }}
+            node_version=${{ needs.validate-release.outputs.node-major }}
             stack_id=${{ env.STACK_ID }}
           platforms: ${{ env.PLATFORMS }}
           pull: true

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ## Порядок обновления версии `NodeJS` базового билдера
 
-Текущий production baseline берётся из `ARG node_image` в `stacks/node/base/Dockerfile`.
+Текущий production baseline берётся из `ARG node_version` в `stacks/node/base/Dockerfile`.
 
 Docker-релиз выполняется через GitHub Actions workflow `Docker release` после merge в `master`.
 Для публикации workflow использует `GITHUB_TOKEN` с доступом `packages: write` и публикует образы в GitHub Container Registry.
 Для Docker Scout scan workflow использует `DOCKERHUB_USERNAME` и `DOCKERHUB_TOKEN` только как Docker Scout credentials.
 
-1. В `stacks/node/base/Dockerfile` обновить `ARG node_image`.
+1. В `stacks/node/base/Dockerfile` обновить `ARG node_version`.
 2. Вмержить PR с релизными изменениями в `master`.
 3. Дождаться прохождения workflow `Docker release`.
 4. Проверить наличие нового тега в [GHCR](https://github.com/orgs/atls/packages/container/package/builder-base).

--- a/stacks/node/base/Dockerfile
+++ b/stacks/node/base/Dockerfile
@@ -1,9 +1,10 @@
-ARG node_image=public.ecr.aws/docker/library/node:26-slim
-FROM ${node_image}
+ARG base_image=mcr.microsoft.com/devcontainers/base:debian-12
+FROM ${base_image}
 
 ARG cnb_uid=1001
 ARG cnb_gid=1001
 ARG stack_id=tech.atlantislab.stacks.node
+ARG node_version=26
 ARG corepack_version=0.35.0
 ARG yarn_version=4.1.1
 
@@ -14,7 +15,13 @@ RUN groupadd cnb --gid ${cnb_gid} && \
   useradd --uid ${cnb_uid} --gid ${cnb_gid} -m -s /bin/bash cnb
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends ca-certificates && \
+  apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${node_version}.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends nodejs && \
+  apt-get purge -y --auto-remove curl gnupg && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
@@ -25,7 +32,7 @@ RUN mkdir -p ${COREPACK_HOME} && \
   chown -R ${cnb_uid}:${cnb_gid} ${COREPACK_HOME}
 
 LABEL io.buildpacks.base.distro.name=Debian
-LABEL io.buildpacks.base.distro.version=trixie
+LABEL io.buildpacks.base.distro.version=bookworm
 LABEL io.buildpacks.stack.id=${stack_id}
 
 # Set required CNB information


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#69

## Как проверять
### Основной сценарий
1. Контекст: `Docker release` после merge в `master`.
Действие: `validate-release` читает `ARG node_version`, проверяет manifest MCR Debian base и запускает stack base build.
Ожидаемый результат: release не тянет `node:*` или mirrored Docker Official Node image и не падает на Docker Hub/ECR pull-rate limit.

### Дополнительный сценарий
1. Контекст: stack base build для release platforms.
Действие: Dockerfile ставит Node.js 26 из NodeSource поверх `mcr.microsoft.com/devcontainers/base:debian-12`.
Ожидаемый результат: собранный image содержит Node.js 26 и Yarn 4.1.1.

## Пруфы
- `actionlint .github/workflows/docker-release.yaml` passed
- `git diff --check` passed
- `bash` release config resolves `base_image=mcr.microsoft.com/devcontainers/base:debian-12` and `node_major=26`
- Поиск старых refs не нашёл `node_image`, `node-image`, `public.ecr.aws/docker/library/node`, `node:26-slim`, `docker.io/atlantislab`.
- `docker build --pull --build-arg node_version=26 ... stacks/node/base` passed on local platform; `node --version` -> `v26.3.0`, `yarn --version` -> `4.1.1`
- `docker buildx build --pull --platform linux/amd64 --build-arg node_version=26 ... --load stacks/node/base` passed; `node --version` -> `v26.3.0`

Failed run being fixed: https://github.com/atls/buildpacks/actions/runs/27576064529
```bash
NODE_IMAGE: public.ecr.aws/docker/library/node:26-slim
docker: toomanyrequests: Rate exceeded
```
