### PR TITLE
fix: bound Docker Scout scan duration

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -557,6 +557,7 @@ jobs:
       - verify-builder-manifest
       - verify-stack-manifests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#71

## Как проверять
### До фикса
1. Контекст: job `scan-release-images` в workflow `Docker release`
Действие: открыть `.github/workflows/docker-release.yaml` и проверить параметры job
Ожидаемый результат: До фикса: у job нет `timeout-minutes`, поэтому зависший Docker Scout вызов может держать release до дефолтного лимита GitHub Actions.

### После фикса
1. Контекст: job `scan-release-images` в workflow `Docker release`
Действие: открыть `.github/workflows/docker-release.yaml` и проверить параметры job
Ожидаемый результат: После фикса: у job задан `timeout-minutes: 10`, поэтому зависший Docker Scout вызов переводит release в управляемый failed state.

## Пруфы
- `actionlint .github/workflows/docker-release.yaml`
```bash
passed
```
- `git diff --check`
```bash
passed
```
- `Docker release` after atls/buildpacks#70
```bash
https://github.com/atls/buildpacks/actions/runs/27577075237
conclusion: success
```
