### PR TITLE
fix(cnb): migrate identity namespace

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -21,7 +21,7 @@ on:
 env:
   IMAGE_PREFIX: ghcr.io/atls
   REGISTRY: ghcr.io
-  STACK_ID: tech.atlantislab.stacks.node
+  STACK_ID: tech.atls.stacks.node
   PACK_VERSION: 0.40.4
   PLATFORMS: linux/amd64,linux/arm64
 

--- a/builders/base/builder.toml
+++ b/builders/base/builder.toml
@@ -19,29 +19,29 @@ os = "linux"
 arch = "arm64"
 
 [[extensions]]
-id = "tech.atlantislab.extensions.curl"
+id = "tech.atls.extensions.curl"
 uri = "docker://ghcr.io/atls/buildpack-extension-curl:0.0.1"
 
 [[extensions]]
-id = "tech.atlantislab.extensions.htop"
+id = "tech.atls.extensions.htop"
 uri = "docker://ghcr.io/atls/buildpack-extension-htop:0.0.1"
 
 [[extensions]]
-id = "tech.atlantislab.extensions.graphql-hive"
+id = "tech.atls.extensions.graphql-hive"
 uri = "docker://ghcr.io/atls/buildpack-extension-graphql-hive:0.0.1"
 
 [[order-extensions]]
 [[order-extensions.group]]
-id = "tech.atlantislab.extensions.curl"
+id = "tech.atls.extensions.curl"
 
 [[order-extensions.group]]
-id = "tech.atlantislab.extensions.htop"
+id = "tech.atls.extensions.htop"
 
 [[order-extensions.group]]
-id = "tech.atlantislab.extensions.graphql-hive"
+id = "tech.atls.extensions.graphql-hive"
 
 # Deprecated
 [stack]
-id = "tech.atlantislab.stacks.node"
+id = "tech.atls.stacks.node"
 run-image = "ghcr.io/atls/stack-node:run"
 build-image = "ghcr.io/atls/stack-node:build"

--- a/buildpacks/require-extension/buildpack.toml
+++ b/buildpacks/require-extension/buildpack.toml
@@ -1,7 +1,7 @@
 api = "0.10"
 
 [buildpack]
-id = "tech.atlantislab.buildpacks.require-extension"
+id = "tech.atls.buildpacks.require-extension"
 version = "0.1.1"
 name = "Extensions requirer"
 

--- a/buildpacks/yarn-cache/buildpack.toml
+++ b/buildpacks/yarn-cache/buildpack.toml
@@ -1,7 +1,7 @@
 api = "0.10"
 
 [buildpack]
-id = "tech.atlantislab.buildpacks.yarn-cache"
+id = "tech.atls.buildpacks.yarn-cache"
 version = "0.1.2"
 name = "Yarn Workspace Pack Buildpack"
 

--- a/buildpacks/yarn-install/buildpack.toml
+++ b/buildpacks/yarn-install/buildpack.toml
@@ -1,7 +1,7 @@
 api = "0.10"
 
 [buildpack]
-id = "tech.atlantislab.buildpacks.yarn-install"
+id = "tech.atls.buildpacks.yarn-install"
 version = "0.1.2"
 name = "Yarn Install Buildpack"
 

--- a/buildpacks/yarn-workspace-start/buildpack.toml
+++ b/buildpacks/yarn-workspace-start/buildpack.toml
@@ -1,7 +1,7 @@
 api = "0.10"
 
 [buildpack]
-id = "tech.atlantislab.buildpacks.yarn-workspace-start"
+id = "tech.atls.buildpacks.yarn-workspace-start"
 version = "0.1.3"
 name = "Yarn Workspace Start Buildpack"
 

--- a/buildpacks/yarn-workspace/buildpack.toml
+++ b/buildpacks/yarn-workspace/buildpack.toml
@@ -1,7 +1,7 @@
 api = "0.10"
 
 [buildpack]
-id = "tech.atlantislab.buildpacks.yarn-workspace"
+id = "tech.atls.buildpacks.yarn-workspace"
 version = "0.1.3"
 name = "Yarn Workspace Buildpack"
 
@@ -10,19 +10,19 @@ include-files = ["buildpack.toml"]
 
 [[order]]
 [[order.group]]
-id = "tech.atlantislab.buildpacks.yarn-install"
+id = "tech.atls.buildpacks.yarn-install"
 optional = true
 version = "0.1.2"
 
 [[order.group]]
-id = "tech.atlantislab.buildpacks.yarn-cache"
+id = "tech.atls.buildpacks.yarn-cache"
 optional = true
 version = "0.1.2"
 
 [[order.group]]
-id = "tech.atlantislab.buildpacks.yarn-workspace-start"
+id = "tech.atls.buildpacks.yarn-workspace-start"
 version = "0.1.3"
 
 [[order.group]]
-id = "tech.atlantislab.buildpacks.require-extension"
+id = "tech.atls.buildpacks.require-extension"
 version = "0.1.1"

--- a/extensions/curl/extension.toml
+++ b/extensions/curl/extension.toml
@@ -1,7 +1,7 @@
 api = "0.10"
 
 [extension]
-id = "tech.atlantislab.extensions.curl"
+id = "tech.atls.extensions.curl"
 version = "0.0.1"
 name = "curl extension"
 homepage = "https://github.com/atls/buildpacks"

--- a/extensions/graphql-hive/extension.toml
+++ b/extensions/graphql-hive/extension.toml
@@ -1,7 +1,7 @@
 api = "0.10"
 
 [extension]
-id = "tech.atlantislab.extensions.graphql-hive"
+id = "tech.atls.extensions.graphql-hive"
 version = "0.0.1"
 name = "graphql-hive extension"
 homepage = "https://github.com/atls/buildpacks"

--- a/extensions/htop/extension.toml
+++ b/extensions/htop/extension.toml
@@ -1,7 +1,7 @@
 api = "0.10"
 
 [extension]
-id = "tech.atlantislab.extensions.htop"
+id = "tech.atls.extensions.htop"
 version = "0.0.1"
 name = "htop extension"
 homepage = "https://github.com/atls/buildpacks"

--- a/stacks/node/base/Dockerfile
+++ b/stacks/node/base/Dockerfile
@@ -3,7 +3,7 @@ FROM ${base_image}
 
 ARG cnb_uid=1001
 ARG cnb_gid=1001
-ARG stack_id=tech.atlantislab.stacks.node
+ARG stack_id=tech.atls.stacks.node
 ARG node_version=26
 ARG corepack_version=0.35.0
 ARG yarn_version=4.1.1


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#74

## Как проверять
### До фикса
1. Контекст: GHCR release publishes `ghcr.io/atls/*` images from the current buildpacks metadata.
Действие: inspect stack, builder, buildpack, extension ids in `stacks/**`, `builders/**`, `buildpacks/**`, `extensions/**`, and `.github/workflows/docker-release.yaml`.
Ожидаемый результат: CNB metadata still uses legacy `tech.atlantislab.*` ids even though image repositories already live under `ghcr.io/atls/*`.

### После фикса
1. Контекст: the same GHCR release path publishes the stack, builder, component buildpacks, composite buildpack, and extensions.
Действие: inspect the same CNB metadata and package the buildpacks with `pack`.
Ожидаемый результат: stack, buildpack, extension, builder references, and workflow `STACK_ID` consistently use `tech.atls.*`; no `tech.atlantislab.*` CNB identity or `atlantislab/*` image registry remains in the release inputs.

## Пруфы
- `rg -n "tech\.atlantislab|atlantislab/" . --glob '!**/node_modules/**' --glob '!**/.git/**'`
```text
no matches
```
- `git diff --check`
```text
passed
```
- `./.yarn/releases/yarn-remote.cjs install --immutable`
```text
passed with Yarn warnings about rebuilt @swc/core artifacts
```
- `./.yarn/releases/yarn-remote.cjs workspace @atls/buildpack-yarn-cache build`
```text
completed
```
- `./.yarn/releases/yarn-remote.cjs workspace @atls/buildpack-yarn-install build`
```text
completed
```
- `./.yarn/releases/yarn-remote.cjs workspace @atls/buildpack-yarn-workspace-start build`
```text
completed
```
- local `pack buildpack package` smoke for `require-extension`, `yarn-install`, `yarn-cache`, `yarn-workspace-start`, and composite `yarn-workspace` using local component archives
```text
verified /cnb/buildpacks/tech.atls.buildpacks.require-extension/0.1.1
verified /cnb/buildpacks/tech.atls.buildpacks.yarn-install/0.1.2
verified /cnb/buildpacks/tech.atls.buildpacks.yarn-cache/0.1.2
verified /cnb/buildpacks/tech.atls.buildpacks.yarn-workspace-start/0.1.3
verified /cnb/buildpacks/tech.atls.buildpacks.yarn-workspace/0.1.3
```
