### PR TITLE
fix(cnb): publish migrated identities under new tags

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -199,15 +199,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: curl
-            directory: extensions/curl
-            image: ghcr.io/atls/buildpack-extension-curl:0.0.1
-          - name: htop
-            directory: extensions/htop
-            image: ghcr.io/atls/buildpack-extension-htop:0.0.1
-          - name: graphql-hive
-            directory: extensions/graphql-hive
-            image: ghcr.io/atls/buildpack-extension-graphql-hive:0.0.1
+              - name: curl
+                directory: extensions/curl
+                image: ghcr.io/atls/buildpack-extension-curl:0.0.2
+              - name: htop
+                directory: extensions/htop
+                image: ghcr.io/atls/buildpack-extension-htop:0.0.2
+              - name: graphql-hive
+                directory: extensions/graphql-hive
+                image: ghcr.io/atls/buildpack-extension-graphql-hive:0.0.2
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/builders/base/builder.toml
+++ b/builders/base/builder.toml
@@ -20,15 +20,15 @@ arch = "arm64"
 
 [[extensions]]
 id = "tech.atls.extensions.curl"
-uri = "docker://ghcr.io/atls/buildpack-extension-curl:0.0.1"
+uri = "docker://ghcr.io/atls/buildpack-extension-curl:0.0.2"
 
 [[extensions]]
 id = "tech.atls.extensions.htop"
-uri = "docker://ghcr.io/atls/buildpack-extension-htop:0.0.1"
+uri = "docker://ghcr.io/atls/buildpack-extension-htop:0.0.2"
 
 [[extensions]]
 id = "tech.atls.extensions.graphql-hive"
-uri = "docker://ghcr.io/atls/buildpack-extension-graphql-hive:0.0.1"
+uri = "docker://ghcr.io/atls/buildpack-extension-graphql-hive:0.0.2"
 
 [[order-extensions]]
 [[order-extensions.group]]

--- a/buildpacks/require-extension/buildpack.toml
+++ b/buildpacks/require-extension/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [buildpack]
 id = "tech.atls.buildpacks.require-extension"
-version = "0.1.1"
+version = "0.1.2"
 name = "Extensions requirer"
 
 [metadata]

--- a/buildpacks/yarn-cache/buildpack.toml
+++ b/buildpacks/yarn-cache/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [buildpack]
 id = "tech.atls.buildpacks.yarn-cache"
-version = "0.1.2"
+version = "0.1.3"
 name = "Yarn Workspace Pack Buildpack"
 
 [metadata]

--- a/buildpacks/yarn-install/buildpack.toml
+++ b/buildpacks/yarn-install/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [buildpack]
 id = "tech.atls.buildpacks.yarn-install"
-version = "0.1.2"
+version = "0.1.3"
 name = "Yarn Install Buildpack"
 
 [metadata]

--- a/buildpacks/yarn-workspace-start/buildpack.toml
+++ b/buildpacks/yarn-workspace-start/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [buildpack]
 id = "tech.atls.buildpacks.yarn-workspace-start"
-version = "0.1.3"
+version = "0.1.4"
 name = "Yarn Workspace Start Buildpack"
 
 [metadata]

--- a/buildpacks/yarn-workspace/buildpack.toml
+++ b/buildpacks/yarn-workspace/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [buildpack]
 id = "tech.atls.buildpacks.yarn-workspace"
-version = "0.1.3"
+version = "0.1.4"
 name = "Yarn Workspace Buildpack"
 
 [metadata]
@@ -12,17 +12,17 @@ include-files = ["buildpack.toml"]
 [[order.group]]
 id = "tech.atls.buildpacks.yarn-install"
 optional = true
-version = "0.1.2"
+version = "0.1.3"
 
 [[order.group]]
 id = "tech.atls.buildpacks.yarn-cache"
 optional = true
-version = "0.1.2"
-
-[[order.group]]
-id = "tech.atls.buildpacks.yarn-workspace-start"
 version = "0.1.3"
 
 [[order.group]]
+id = "tech.atls.buildpacks.yarn-workspace-start"
+version = "0.1.4"
+
+[[order.group]]
 id = "tech.atls.buildpacks.require-extension"
-version = "0.1.1"
+version = "0.1.2"

--- a/buildpacks/yarn-workspace/package.toml
+++ b/buildpacks/yarn-workspace/package.toml
@@ -2,13 +2,13 @@
 uri = "."
 
 [[dependencies]]
-uri = "docker://ghcr.io/atls/buildpack-require-extension:0.1.1"
+uri = "docker://ghcr.io/atls/buildpack-require-extension:0.1.2"
 
 [[dependencies]]
-uri = "docker://ghcr.io/atls/buildpack-yarn-install:0.1.2"
+uri = "docker://ghcr.io/atls/buildpack-yarn-install:0.1.3"
 
 [[dependencies]]
-uri = "docker://ghcr.io/atls/buildpack-yarn-cache:0.1.2"
+uri = "docker://ghcr.io/atls/buildpack-yarn-cache:0.1.3"
 
 [[dependencies]]
-uri = "docker://ghcr.io/atls/buildpack-yarn-workspace-start:0.1.3"
+uri = "docker://ghcr.io/atls/buildpack-yarn-workspace-start:0.1.4"

--- a/extensions/curl/extension.toml
+++ b/extensions/curl/extension.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [extension]
 id = "tech.atls.extensions.curl"
-version = "0.0.1"
+version = "0.0.2"
 name = "curl extension"
 homepage = "https://github.com/atls/buildpacks"
 description = "Installs curl on the runtime base image"

--- a/extensions/graphql-hive/extension.toml
+++ b/extensions/graphql-hive/extension.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [extension]
 id = "tech.atls.extensions.graphql-hive"
-version = "0.0.1"
+version = "0.0.2"
 name = "graphql-hive extension"
 homepage = "https://github.com/atls/buildpacks"
 description = "Installs graphql-hive on the runtime base image"

--- a/extensions/htop/extension.toml
+++ b/extensions/htop/extension.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [extension]
 id = "tech.atls.extensions.htop"
-version = "0.0.1"
+version = "0.0.2"
 name = "htop extension"
 homepage = "https://github.com/atls/buildpacks"
 description = "Installs htop on the runtime base image"


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#76

## Как проверять
### До фикса
1. Контекст: atls/buildpacks#75 migrates CNB ids from `tech.atlantislab.*` to `tech.atls.*`.
Действие: inspect buildpack and extension versions plus Docker release image tags.
Ожидаемый результат: migrated CNB identities are still published under old semver tags, overwriting rollback artifacts like `buildpack-yarn-workspace:0.1.3` and `buildpack-extension-curl:0.0.1`.

### После фикса
1. Контекст: the same migrated CNB identities are released through `Docker release`.
Действие: inspect component versions, composite dependencies, builder extension references, and extension publish tags.
Ожидаемый результат: changed CNB identities publish under new semver tags: extensions `0.0.2`, require-extension `0.1.2`, yarn install/cache `0.1.3`, yarn-workspace-start and yarn-workspace `0.1.4`; composite and builder references point to those new tags.

## Пруфы
- `git diff --check`
```text
passed
```
- `./.yarn/releases/yarn-remote.cjs workspace @atls/buildpack-yarn-cache build`
```text
completed
```
- `./.yarn/releases/yarn-remote.cjs workspace @atls/buildpack-yarn-install build`
```text
completed
```
- `./.yarn/releases/yarn-remote.cjs workspace @atls/buildpack-yarn-workspace-start build`
```text
completed
```
- local `pack buildpack package` smoke for `require-extension`, `yarn-install`, `yarn-cache`, `yarn-workspace-start`, and composite `yarn-workspace` using local component archives
```text
verified /cnb/buildpacks/tech.atls.buildpacks.require-extension/0.1.2
verified /cnb/buildpacks/tech.atls.buildpacks.yarn-install/0.1.3
verified /cnb/buildpacks/tech.atls.buildpacks.yarn-cache/0.1.3
verified /cnb/buildpacks/tech.atls.buildpacks.yarn-workspace-start/0.1.4
verified /cnb/buildpacks/tech.atls.buildpacks.yarn-workspace/0.1.4
```
