### PR TITLE
fix(release): use configured github token

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Create GitHub releases
         uses: googleapis/release-please-action@v4.4.1
         with:
-          token: ${{ secrets.PAT_token }}
+          token: ${{ secrets.GH_TOKEN }}
           target-branch: master
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Create release PR
         uses: googleapis/release-please-action@v4.4.1
         with:
-          token: ${{ secrets.PAT_token }}
+          token: ${{ secrets.GH_TOKEN }}
           target-branch: master
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Semver buildpack tags остаются pin/rollback-артефактами. Node
 Release PR создаёт GitHub Actions workflow `Release PR` после merge в `master`.
 GitHub release и tag создаёт workflow `GitHub release` только после successful `Docker release` на том же head SHA, где изменился `.release-please-manifest.json`.
 Workflow использует `release-please-action` с правами `contents: write`, `issues: write` и `pull-requests: write`.
-Для создания release PR используется `PAT_token`, чтобы созданные PR запускали обычные проверки `pull_request`.
+Для создания release PR используется org secret `GH_TOKEN`, чтобы созданные PR запускали обычные проверки `pull_request`.
 Buildpack-компоненты связаны через `release-please` `linked-versions` group `cnb-buildpack-family`.
 В эту группу входит `libcnb`, поэтому изменение общей CNB-библиотеки поднимает версии зависящих buildpack-компонентов тем же release PR.
 


### PR DESCRIPTION
## Что исправлено

- Переключил `Release PR` и `GitHub release` workflows с отсутствующего `PAT_token` на существующий org secret `GH_TOKEN`.
- Обновил README, чтобы документация совпадала с реальным источником токена.

## Почему

Post-merge `Release PR` после #79 упал на run https://github.com/atls/buildpacks/actions/runs/27731944828 с ошибкой `release-please failed: Input required and not supplied: token`.

## Проверки

- `actionlint .github/workflows/release-pr.yaml .github/workflows/github-release.yaml`
- `git diff --check`

Refs #79