### PR TITLE
fix(release): mint app token for release please

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -79,10 +79,17 @@ jobs:
     if: ${{ needs.detect-release-head.outputs.should_release == 'true' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Create app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.ATLANTIS_SUPER_BOT_APP_ID }}
+          private-key: ${{ secrets.ATLANTIS_SUPER_BOT_PRIVATE_KEY }}
+
       - name: Create GitHub releases
         uses: googleapis/release-please-action@v4.4.1
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           target-branch: master
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -72,10 +72,17 @@ jobs:
     if: ${{ needs.detect-release-head.outputs.should_create_pr == 'true' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Create app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.ATLANTIS_SUPER_BOT_APP_ID }}
+          private-key: ${{ secrets.ATLANTIS_SUPER_BOT_PRIVATE_KEY }}
+
       - name: Create release PR
         uses: googleapis/release-please-action@v4.4.1
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           target-branch: master
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Semver buildpack tags остаются pin/rollback-артефактами. Node
 Release PR создаёт GitHub Actions workflow `Release PR` после merge в `master`.
 GitHub release и tag создаёт workflow `GitHub release` только после successful `Docker release` на том же head SHA, где изменился `.release-please-manifest.json`.
 Workflow использует `release-please-action` с правами `contents: write`, `issues: write` и `pull-requests: write`.
-Для создания release PR используется org secret `GH_TOKEN`, чтобы созданные PR запускали обычные проверки `pull_request`.
+Для создания release PR используется GitHub App token из `ATLANTIS_SUPER_BOT_APP_ID` и `ATLANTIS_SUPER_BOT_PRIVATE_KEY`, чтобы созданные PR запускали обычные проверки `pull_request`.
 Buildpack-компоненты связаны через `release-please` `linked-versions` group `cnb-buildpack-family`.
 В эту группу входит `libcnb`, поэтому изменение общей CNB-библиотеки поднимает версии зависящих buildpack-компонентов тем же release PR.
 


### PR DESCRIPTION
## Что исправлено

- Добавил `actions/create-github-app-token@v2` в `Release PR` и `GitHub release` workflows.
- Передаю `release-please-action` short-lived GitHub App token вместо нерабочего `GH_TOKEN`.
- Обновил README под фактический токен-контракт.

## Почему

PR #80 устранил пустой token input, но post-merge `Release PR` всё равно упал: https://github.com/atls/buildpacks/actions/runs/27733387714

Ошибка: `release-please failed: Bad credentials`.

В org уже есть рабочий паттерн `actions/create-github-app-token@v2` с `ATLANTIS_SUPER_BOT_APP_ID` / `ATLANTIS_SUPER_BOT_PRIVATE_KEY`; этот PR переносит тот же контракт в buildpacks release workflows.

## Проверки

- `actionlint .github/workflows/release-pr.yaml .github/workflows/github-release.yaml`
- `git diff --check`

Refs #80
Refs #79