### PR TITLE
chore(release): rename lifecycle labels

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -51,7 +51,7 @@ jobs:
           mapfile -t pending_release_prs < <(
             gh pr list \
               --state merged \
-              --label 'autorelease: pending' \
+              --label 'release: pending' \
               --limit 100 \
               --json number,mergeCommit \
               --jq '.[] | [.number, .mergeCommit.oid] | @tsv'

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -45,7 +45,7 @@ jobs:
           mapfile -t pending_release_heads < <(
             gh pr list \
               --state merged \
-              --label 'autorelease: pending' \
+              --label 'release: pending' \
               --limit 100 \
               --json mergeCommit \
               --jq '.[] | .mergeCommit.oid // empty'

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,8 @@
   "bootstrap-sha": "98386bca9834ab0bfc627549f949f794817fad62",
   "include-v-in-tag": false,
   "skip-changelog": true,
+  "label": "release: pending",
+  "release-label": "release: tagged",
   "changelog-sections": [
     {
       "type": "feat",


### PR DESCRIPTION
## Что изменено

- Настроил `release-please` lifecycle labels: `release: pending` и `release: tagged`.
- Перевёл `Release PR` и `GitHub release` detectors на `release: pending`.
- Создал repo labels `release: pending` и `release: tagged`.

## Почему

`autorelease:*` labels являются частью release-please state machine, но публично выглядят как внешняя служебная деталь. Оставляем штатный lifecycle, но переименовываем labels в наш нейтральный namespace.

## Проверки

- `actionlint .github/workflows/release-pr.yaml .github/workflows/github-release.yaml`
- JSON parse `release-please-config.json`
- `git diff --check`

Refs #82