### PR TITLE
fix(stack): refresh Debian packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 Docker-релиз выполняется через GitHub Actions workflow `Docker release` после merge в `master`.
 Для публикации workflow использует `GITHUB_TOKEN` с доступом `packages: write` и публикует образы в GitHub Container Registry.
+Базовый stack слой обновляет установленные Debian-пакеты перед установкой Node.js, чтобы release images не наследовали исправимые OS-уязвимости из upstream base image.
 Проверка опубликованных GHCR-образов выполняется через Trivy; отчёты загружаются в GitHub code scanning как SARIF.
 
 1. В `.github/docker-release-node-lines.json` добавить или удалить supported Node major.

--- a/stacks/node/base/Dockerfile
+++ b/stacks/node/base/Dockerfile
@@ -15,6 +15,7 @@ RUN groupadd cnb --gid ${cnb_gid} && \
   useradd --uid ${cnb_uid} --gid ${cnb_gid} -m -s /bin/bash cnb
 
 RUN apt-get update && \
+  apt-get upgrade -y && \
   apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
   mkdir -p /etc/apt/keyrings && \
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#87

## Как проверять
### До фикса
1. Контекст: job `Docker release` после #86
Действие: дождаться шага `Gate critical fixed vulnerabilities` для Node stack/builder images
Ожидаемый результат: Trivy останавливает выпуск на исправимых critical finding в Debian-пакетах базового stack слоя

### После фикса
1. Контекст: job `Docker release` после merge этого PR
Действие: дождаться scan, promotion и verification jobs для Node 24/26
Ожидаемый результат: базовый stack слой собран с обновлёнными Debian-пакетами, Trivy critical gate проходит, release tags продвигаются

## Пруфы
- `git diff --check`
```bash
passed
```
- `docker build --check --build-arg node_version=24 --build-arg stack_id=tech.atls.stacks.node stacks/node/base`
```bash
Check complete, no warnings found.
```
- `docker build --pull --build-arg node_version=24 --build-arg stack_id=tech.atls.stacks.node -t buildpacks-stack-base-test:24 stacks/node/base`
```bash
Запущен локально на linux/arm64. До остановки сборки подтверждено, что apt-get upgrade выбирает libgnutls30 среди обновляемых Debian-пакетов. Сборка остановлена вручную до завершения, потому что загрузка Debian-пакетов локально шла слишком медленно; финальная multi-arch проверка выполняется post-merge Docker release.
```
