### PR TITLE
ci(release): enable release PR auto-merge

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -87,3 +87,43 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           skip-github-release: true
+
+      - name: Enable release PR auto-merge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_PR_BRANCH: release-please--branches--master
+          RELEASE_PR_LABEL: 'release: pending'
+        run: |
+          mapfile -t release_prs < <(
+            gh pr list \
+              --state open \
+              --head "${RELEASE_PR_BRANCH}" \
+              --label "${RELEASE_PR_LABEL}" \
+              --json number,isDraft,headRefName \
+              --jq '.[] | [.number, .isDraft, .headRefName] | @tsv'
+          )
+
+          release_pr_count="${#release_prs[@]}"
+          if [[ "${release_pr_count}" -eq 0 ]]; then
+            echo 'No release PR found for auto-merge'
+            exit 0
+          fi
+
+          if [[ "${release_pr_count}" -ne 1 ]]; then
+            echo "Expected exactly one release PR, got ${release_pr_count}" >&2
+            exit 1
+          fi
+
+          read -r release_pr_number release_pr_draft release_pr_head <<< "${release_prs[0]}"
+
+          if [[ "${release_pr_head}" != "${RELEASE_PR_BRANCH}" ]]; then
+            echo "Unexpected release PR head: ${release_pr_head}" >&2
+            exit 1
+          fi
+
+          if [[ "${release_pr_draft}" == 'true' ]]; then
+            echo "Release PR #${release_pr_number} is draft" >&2
+            exit 1
+          fi
+
+          gh pr merge "${release_pr_number}" --auto --merge

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -80,6 +80,7 @@ jobs:
           private-key: ${{ secrets.ATLANTIS_SUPER_BOT_PRIVATE_KEY }}
 
       - name: Create release PR
+        id: release-please
         uses: googleapis/release-please-action@v4.4.1
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -89,41 +90,8 @@ jobs:
           skip-github-release: true
 
       - name: Enable release PR auto-merge
+        if: ${{ steps.release-please.outputs.prs_created == 'true' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          RELEASE_PR_BRANCH: release-please--branches--master
-          RELEASE_PR_LABEL: 'release: pending'
-        run: |
-          mapfile -t release_prs < <(
-            gh pr list \
-              --state open \
-              --head "${RELEASE_PR_BRANCH}" \
-              --label "${RELEASE_PR_LABEL}" \
-              --json number,isDraft,headRefName \
-              --jq '.[] | [.number, .isDraft, .headRefName] | @tsv'
-          )
-
-          release_pr_count="${#release_prs[@]}"
-          if [[ "${release_pr_count}" -eq 0 ]]; then
-            echo 'No release PR found for auto-merge'
-            exit 0
-          fi
-
-          if [[ "${release_pr_count}" -ne 1 ]]; then
-            echo "Expected exactly one release PR, got ${release_pr_count}" >&2
-            exit 1
-          fi
-
-          read -r release_pr_number release_pr_draft release_pr_head <<< "${release_prs[0]}"
-
-          if [[ "${release_pr_head}" != "${RELEASE_PR_BRANCH}" ]]; then
-            echo "Unexpected release PR head: ${release_pr_head}" >&2
-            exit 1
-          fi
-
-          if [[ "${release_pr_draft}" == 'true' ]]; then
-            echo "Release PR #${release_pr_number} is draft" >&2
-            exit 1
-          fi
-
-          gh pr merge "${release_pr_number}" --auto --merge
+          RELEASE_PR_NUMBER: ${{ fromJSON(steps.release-please.outputs.prs)[0].number }}
+        run: gh pr merge "${RELEASE_PR_NUMBER}" --auto --merge

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -93,5 +93,6 @@ jobs:
         if: ${{ steps.release-please.outputs.prs_created == 'true' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_PR_NUMBER: ${{ fromJSON(steps.release-please.outputs.prs)[0].number }}
         run: gh pr merge "${RELEASE_PR_NUMBER}" --auto --merge


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#94

## Как проверять
### Основной сценарий
1. Контекст: Release PR workflow создал или обновил release-please PR
Действие: дождаться шага `Enable release PR auto-merge`
Ожидаемый результат: workflow берёт номер PR из output `prs` шага `Create release PR`, а не ищет PR повторно через GitHub CLI.

2. Контекст: release-please вернул созданный или обновлённый PR
Действие: выполнить `gh pr merge <number> --auto --merge`
Ожидаемый результат: GitHub включает auto-merge для этого PR, а branch protection остаётся gate для required checks.

3. Контекст: release-please не создал и не обновил PR
Действие: выполнить workflow
Ожидаемый результат: шаг auto-merge пропускается по output `prs_created`, workflow не мержит произвольные PR.

## Пруфы
- `actionlint .github/workflows/release-pr.yaml` проходит.
- `git diff --check` проходит.
- `gh api repos/atls/buildpacks --jq '{allow_auto_merge,delete_branch_on_merge,visibility}'` подтвердил `allow_auto_merge: true`.
