### PR TITLE
fix(release): skip auto-merge without release PR output

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -90,7 +90,7 @@ jobs:
           skip-github-release: true
 
       - name: Enable release PR auto-merge
-        if: ${{ steps.release-please.outputs.prs_created == 'true' }}
+        if: ${{ steps.release-please.outputs.prs_created == 'true' && steps.release-please.outputs.prs != '' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Таска
- Refs atls/buildpacks#95

## Как проверять
1. Контекст: release-please завершил шаг без созданного или обновлённого PR и output `prs` пустой
Действие: выполнить workflow `Release PR`
Ожидаемый результат: шаг `Enable release PR auto-merge` пропускается и не пытается парсить пустой JSON.

2. Контекст: release-please вернул непустой output `prs`
Действие: выполнить workflow `Release PR`
Ожидаемый результат: workflow берёт номер PR из output `prs` и включает auto-merge для этого PR.

## Пруфы
- `actionlint .github/workflows/release-pr.yaml` проходит.
- `git diff --check` проходит.
- Post-merge failure после #95: https://github.com/atls/buildpacks/actions/runs/27914008672
