### PR TITLE
fix(release): parse release PR output inside step

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -90,9 +90,21 @@ jobs:
           skip-github-release: true
 
       - name: Enable release PR auto-merge
-        if: ${{ steps.release-please.outputs.prs_created == 'true' && steps.release-please.outputs.prs != '' }}
+        if: ${{ steps.release-please.outputs.prs_created == 'true' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
-          RELEASE_PR_NUMBER: ${{ fromJSON(steps.release-please.outputs.prs)[0].number }}
-        run: gh pr merge "${RELEASE_PR_NUMBER}" --auto --merge
+          RELEASE_PRS: ${{ steps.release-please.outputs.prs }}
+        run: |
+          if [[ -z "${RELEASE_PRS}" ]]; then
+            echo 'No release PR returned for auto-merge'
+            exit 0
+          fi
+
+          release_pr_number="$(jq -r '.[0].number // empty' <<< "${RELEASE_PRS}")"
+          if [[ -z "${release_pr_number}" ]]; then
+            echo 'Release PR output does not contain a pull request number' >&2
+            exit 1
+          fi
+
+          gh pr merge "${release_pr_number}" --auto --merge


### PR DESCRIPTION
## Таска
- Refs atls/buildpacks#96

## Как проверять
1. Контекст: release-please завершил шаг без созданного или обновлённого PR и output `prs` пустой
Действие: выполнить workflow `Release PR`
Ожидаемый результат: шаг `Enable release PR auto-merge` не вызывает `fromJSON` в GitHub expression и завершается без ошибки.

2. Контекст: release-please вернул непустой output `prs`
Действие: выполнить workflow `Release PR`
Ожидаемый результат: workflow читает номер PR из output `prs` внутри shell step и включает auto-merge для этого PR.

## Пруфы
- `actionlint .github/workflows/release-pr.yaml` проходит.
- `git diff --check` проходит.
- Post-merge failure после #96: https://github.com/atls/buildpacks/actions/runs/27914244198
