### PR TITLE
docs: rewrite public README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ builder and buildpack images.
 
 ## Build An Application
 
-These examples assume a zero-install Yarn workspace with .yarn/cache committed
-and a start-image script in package.json.
+These examples assume a Yarn zero-install Plug'n'Play workspace with a
+start-image script in package.json.
 
 Use Node 26 for new applications:
 
@@ -79,19 +79,10 @@ builder-base:26 and buildpack-yarn-workspace:26.
 
 ## Yarn Workspace Buildpack
 
-buildpack-yarn-workspace is the application buildpack for zero-install Yarn
-workspace projects.
+buildpack-yarn-workspace is the application buildpack for Yarn zero-install
+Plug'n'Play workspace projects.
 
-The application repository must include:
-
-- package.json;
-- yarn.lock;
-- .yarn/cache;
-- a start-image script in package.json.
-
-The install and cache buildpacks run only when yarn.lock and .yarn/cache are
-present. Repositories that do not commit .yarn/cache need a separate dependency
-installation step.
+The buildpack-specific launch contract is a start-image script in package.json.
 
 For Yarn Plug'n'Play applications, the buildpack prepares launch-time Node
 options:
@@ -106,14 +97,14 @@ can stay simple:
 ```json
 {
   "scripts": {
-    "start-image": "node dist/index.js"
+    "start-image": "node server.js"
   }
 }
 ```
 
-The image start buildpack runs yarn start-image. Do not duplicate Plug'n'Play
-loader flags in that script unless the application intentionally overrides the
-buildpack behavior.
+The image start buildpack runs yarn start-image. That script should start the
+application entrypoint. Do not duplicate Plug'n'Play loader flags in it unless
+the application intentionally overrides the buildpack behavior.
 
 ## Builder And Buildpack
 

--- a/README.md
+++ b/README.md
@@ -1,113 +1,144 @@
-# Buildpacks
+# ATLS Buildpacks
 
-[<img src="https://img.shields.io/static/v1?style=for-the-badge&label=%40atls%2Fcode-service&message=0.0.25&labelColor=ECEEF5&color=D7DCEB">](https://npmjs.com/package/@atls/code-service)
-[<img src="https://img.shields.io/static/v1?style=for-the-badge&label=%40atls%2Fschematics&message=0.0.21&labelColor=ECEEF5&color=D7DCEB">](https://npmjs.com/package/@atls/schematics)
+Buildpacks, builders and stack images for Node.js applications that use Yarn
+workspaces.
 
-## Порядок обновления версий Node.js базового билдера
+The images are published in GitHub Container Registry. They are public and can
+be used with `pack`, CI jobs, or any tool that accepts Cloud Native Buildpacks
+builder and buildpack images.
 
-Поддерживаемые линейки Node.js для Docker-релиза задаются в
-`.github/docker-release-node-lines.json`.
-Поле `default` должно совпадать с `ARG node_version` в `stacks/node/base/Dockerfile`.
-Оно управляет алиасами без номера линейки Node.js.
+## Build An Application
 
-Docker-релиз выполняет рабочий процесс GitHub Actions Docker release после слияния в
-`master`.
-Для публикации используется `GITHUB_TOKEN` с доступом `packages: write`.
-Образы публикуются в GitHub Container Registry.
+Use Node 26 for new applications:
 
-Базовый слой стека обновляет установленные Debian-пакеты перед установкой Node.js.
-Так релизные образы не наследуют исправимые уязвимости операционной системы из
-исходного базового образа.
-Опубликованные GHCR-образы проверяет Trivy.
-Отчёты загружаются в GitHub code scanning в формате SARIF.
+```bash
+pack build my-app \
+  --builder ghcr.io/atls/builder-base:26 \
+  --buildpack ghcr.io/atls/buildpack-yarn-workspace:26
+```
 
-1. В `.github/docker-release-node-lines.json` добавить или удалить поддерживаемую линейку
-   Node.js.
-2. Если меняется линейка по умолчанию, обновить `default` в
-   `.github/docker-release-node-lines.json` и `ARG node_version` в
-   `stacks/node/base/Dockerfile`.
-3. Вмержить PR с релизными изменениями в `master`.
-4. Дождаться прохождения рабочего процесса Docker release.
-5. Проверить наличие нового тега в
-   [GHCR](https://github.com/orgs/atls/packages/container/package/builder-base).
+Use Node 24 when the application must stay on Node 24:
 
-Рабочий процесс публикует:
+```bash
+pack build my-app \
+  --builder ghcr.io/atls/builder-base:24 \
+  --buildpack ghcr.io/atls/buildpack-yarn-workspace:24
+```
 
-1. Неизменяемые теги стека:
-   `ghcr.io/atls/stack-node:base-<node-major>-<sha>`,
-   `build-<node-major>-<sha>`, `run-<node-major>-<sha>`.
-2. Канальные теги стека для каждой поддерживаемой линейки Node.js:
-   `ghcr.io/atls/stack-node:base-<node-major>`, `build-<node-major>`,
-   `run-<node-major>`.
-3. Алиасы без номера линейки: `ghcr.io/atls/stack-node:base`, `build`, `run`.
-   Они указывают только на Node.js из `default`.
-4. Buildpack-теги с семантической версией: `ghcr.io/atls/buildpack-*:<version>`.
-5. Канальные теги группы buildpack для каждой поддерживаемой линейки Node.js:
-   `ghcr.io/atls/buildpack-yarn-workspace:<node-major>`.
-6. Неизменяемые builder-теги: `ghcr.io/atls/builder-base:<node-major>-<sha>`.
-7. Канальные builder-теги: `ghcr.io/atls/builder-base:<node-major>`.
-   Они собираются из тегов стека той же линейки Node.js.
+The builder provides the Node stack and CNB lifecycle. The buildpack prepares a
+Yarn workspace application for build and launch.
 
-Buildpack-теги с семантической версией остаются артефактами для фиксации и отката.
-Канальные теги по линейке Node.js подходят потребителям, которым нужен актуальный
-проверенный buildpack без обновления патч-версии после каждого релиза.
+## Images
 
-## Порядок обновления версий CNB buildpack-компонентов
+| Image | Use it for |
+| --- | --- |
+| `ghcr.io/atls/builder-base` | Building application images with the ATLS Node stack. |
+| `ghcr.io/atls/buildpack-yarn-workspace` | Building Yarn workspace applications. |
+| `ghcr.io/atls/stack-node` | Stack base, build and run images used by the builder. |
 
-Версии buildpack и extension-компонентов ведутся через `release-please-config.json` и
-`.release-please-manifest.json`.
-Релизный PR создаёт рабочий процесс GitHub Actions Release PR после слияния в
-`master`.
-GitHub release и тег создаёт рабочий процесс GitHub release.
-Он запускается только после успешного Docker release на том же SHA head-коммита, где
-изменился `.release-please-manifest.json`.
+All release images are published for `linux/amd64` and `linux/arm64`.
 
-Рабочий процесс использует `release-please-action` с правами `contents: write`,
-`issues: write` и `pull-requests: write`.
-Для создания релизного PR используется токен GitHub App из
-`ATLANTIS_SUPER_BOT_APP_ID` и `ATLANTIS_SUPER_BOT_PRIVATE_KEY`.
-Так созданные PR запускают обычные проверки `pull_request`.
+## Tags
 
-Buildpack-компоненты связаны через группу `cnb-buildpack-family` в
-`release-please` `linked-versions`.
-В эту группу входит `libcnb`.
-Поэтому изменение общей CNB-библиотеки поднимает версии зависящих
-buildpack-компонентов тем же релизным PR.
+Use Node-line tags for normal application builds:
 
-Составной buildpack `buildpack-yarn-workspace` получает ссылки на связанные
-компонентные buildpacks в том же релизном PR.
-Для этого используются маркеры `release-please` в
-`buildpacks/yarn-workspace/package.toml` и `buildpacks/yarn-workspace/buildpack.toml`.
+```text
+ghcr.io/atls/builder-base:26
+ghcr.io/atls/buildpack-yarn-workspace:26
+```
 
-`jam update-buildpack` для этих файлов не используется.
-Он переписывает TOML без сохранения marker-комментариев.
-После этого `release-please` перестаёт синхронизировать ссылки составного buildpack.
+Available Node lines:
 
-Extension-компоненты связаны через группу `cnb-extension-family` в `release-please`
-`linked-versions`.
-`builders/base/builder.toml` получает ссылки на связанные образы расширений в том же
-релизном PR.
-Docker release берёт публикуемый тег из соответствующего `extension.toml`.
+```text
+24
+26
+```
 
-`jam update-builder` сейчас не используется.
-`builder-base` остаётся базовым builder: он содержит lifecycle, образы стека и
-расширения.
-`buildpack-yarn-workspace` выбирает Raijin image pack.
+Node-line tags move to the latest published image for that Node line. Use them
+when an application should receive the current validated builder and buildpack
+for its Node version.
 
-Кроме того, `jam update-builder` ожидает теги build/run-образов с семантической
-версией.
-`stack-node` публикуется канальными и SHA-тегами вроде `build-24`, `run-24` и
-`build-24-<sha>`.
+Use semantic version tags when a rollout needs a fixed buildpack version:
 
-## Запуск Yarn PnP ESM workspace
+```text
+ghcr.io/atls/buildpack-yarn-workspace:0.2.2
+```
 
-`buildpack-yarn-workspace-start` формирует слой запуска с `NODE_OPTIONS` для
-workspace без `node_modules`.
+Stack images use role-specific tags:
 
-Если в приложении есть `.pnp.cjs`, buildpack добавляет его через `--require`.
-Если в приложении есть `.pnp.loader.mjs`, buildpack добавляет его через `--loader`.
-Карты исходников включаются через `--enable-source-maps`.
+```text
+ghcr.io/atls/stack-node:base-26
+ghcr.io/atls/stack-node:build-26
+ghcr.io/atls/stack-node:run-26
+```
 
-Прикладной `package.json` не должен дублировать эти флаги в `start`-команде.
-Для ESM workspace достаточно запускать собранную точку входа, например
-`node dist/index.js`.
+The same tags exist for Node 24. Tags without a Node suffix currently point to
+the default Node line, which is Node 26:
+
+```text
+ghcr.io/atls/stack-node:base
+ghcr.io/atls/stack-node:build
+ghcr.io/atls/stack-node:run
+```
+
+For application configuration, prefer explicit Node-line tags such as
+`builder-base:26` and `buildpack-yarn-workspace:26`.
+
+## Yarn Workspace Buildpack
+
+`buildpack-yarn-workspace` is the application buildpack for Yarn workspace
+projects. It combines install, cache and launch behavior into one buildpack
+image.
+
+For Yarn Plug'n'Play applications, the buildpack prepares launch-time Node
+options:
+
+- loads `.pnp.cjs` with `--require`;
+- loads `.pnp.loader.mjs` with `--loader`;
+- enables source maps.
+
+Because the buildpack owns these launch options, the application start command
+can stay simple:
+
+```json
+{
+  "scripts": {
+    "start": "node dist/index.js"
+  }
+}
+```
+
+Do not duplicate Plug'n'Play loader flags in the application start script unless
+the application intentionally overrides the buildpack behavior.
+
+## Builder And Buildpack
+
+`builder-base` is a base builder. It does not make every application buildable by
+itself.
+
+For Yarn workspace applications, pass both images:
+
+```bash
+pack build my-app \
+  --builder ghcr.io/atls/builder-base:26 \
+  --buildpack ghcr.io/atls/buildpack-yarn-workspace:26
+```
+
+Tools that wrap CNB builds should use the same pair: one builder image and one
+application buildpack image for the selected Node line.
+
+## Registry
+
+- [builder-base](https://github.com/orgs/atls/packages/container/package/builder-base)
+- [buildpack-yarn-workspace](https://github.com/orgs/atls/packages/container/package/buildpack-yarn-workspace)
+- [stack-node](https://github.com/orgs/atls/packages/container/package/stack-node)
+
+Component buildpacks and extensions are also published in GHCR:
+
+- `buildpack-yarn-install`
+- `buildpack-yarn-cache`
+- `buildpack-yarn-workspace-start`
+- `buildpack-require-extension`
+- `buildpack-extension-curl`
+- `buildpack-extension-htop`
+- `buildpack-extension-graphql-hive`

--- a/README.md
+++ b/README.md
@@ -49,10 +49,8 @@ ghcr.io/atls/buildpack-yarn-workspace:26
 
 Available Node lines:
 
-```text
-24
-26
-```
+- Node 24
+- Node 26
 
 Node-line tags move to the latest published image for that Node line. Use them
 when an application should receive the current validated builder and buildpack
@@ -60,26 +58,20 @@ for its Node version.
 
 Use semantic version tags when a rollout needs a fixed buildpack version:
 
-```text
-ghcr.io/atls/buildpack-yarn-workspace:0.2.2
-```
+- `ghcr.io/atls/buildpack-yarn-workspace:0.2.2`
 
 Stack images use role-specific tags:
 
-```text
-ghcr.io/atls/stack-node:base-26
-ghcr.io/atls/stack-node:build-26
-ghcr.io/atls/stack-node:run-26
-```
+- `ghcr.io/atls/stack-node:base-26`
+- `ghcr.io/atls/stack-node:build-26`
+- `ghcr.io/atls/stack-node:run-26`
 
 The same tags exist for Node 24. Tags without a Node suffix currently point to
 the default Node line, which is Node 26:
 
-```text
-ghcr.io/atls/stack-node:base
-ghcr.io/atls/stack-node:build
-ghcr.io/atls/stack-node:run
-```
+- `ghcr.io/atls/stack-node:base`
+- `ghcr.io/atls/stack-node:build`
+- `ghcr.io/atls/stack-node:run`
 
 For application configuration, prefer explicit Node-line tags such as
 `builder-base:26` and `buildpack-yarn-workspace:26`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ builder and buildpack images.
 ## Build An Application
 
 These examples assume a zero-install Yarn workspace with `.yarn/cache`
-committed.
+committed and a `start-image` script in `package.json`.
 
 Use Node 26 for new applications:
 
@@ -88,7 +88,8 @@ The application repository must include:
 
 - `package.json`;
 - `yarn.lock`;
-- `.yarn/cache`.
+- `.yarn/cache`;
+- a `start-image` script in `package.json`.
 
 The install and cache buildpacks run only when `yarn.lock` and `.yarn/cache` are
 present. Repositories that do not commit `.yarn/cache` need a separate
@@ -101,19 +102,20 @@ options:
 - loads `.pnp.loader.mjs` with `--loader`;
 - enables source maps.
 
-Because the buildpack owns these launch options, the application start command
+Because the buildpack owns these launch options, the application launch script
 can stay simple:
 
 ```json
 {
   "scripts": {
-    "start": "node dist/index.js"
+    "start-image": "node dist/index.js"
   }
 }
 ```
 
-Do not duplicate Plug'n'Play loader flags in the application start script unless
-the application intentionally overrides the buildpack behavior.
+The image start buildpack runs `yarn start-image`. Do not duplicate Plug'n'Play
+loader flags in that script unless the application intentionally overrides the
+buildpack behavior.
 
 ## Builder And Buildpack
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,8 @@ All release images are published for `linux/amd64` and `linux/arm64`.
 
 Use Node-line tags for normal application builds:
 
-```text
-ghcr.io/atls/builder-base:26
-ghcr.io/atls/buildpack-yarn-workspace:26
-```
+- `ghcr.io/atls/builder-base:26`
+- `ghcr.io/atls/buildpack-yarn-workspace:26`
 
 Available Node lines:
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ builder and buildpack images.
 
 ## Build An Application
 
+These examples assume a zero-install Yarn workspace with `.yarn/cache`
+committed.
+
 Use Node 26 for new applications:
 
 ```bash
@@ -26,7 +29,7 @@ pack build my-app \
 ```
 
 The builder provides the Node stack and CNB lifecycle. The buildpack prepares a
-Yarn workspace application for build and launch.
+zero-install Yarn workspace application for build and launch.
 
 ## Images
 
@@ -78,9 +81,18 @@ For application configuration, prefer explicit Node-line tags such as
 
 ## Yarn Workspace Buildpack
 
-`buildpack-yarn-workspace` is the application buildpack for Yarn workspace
-projects. It combines install, cache and launch behavior into one buildpack
-image.
+`buildpack-yarn-workspace` is the application buildpack for zero-install Yarn
+workspace projects.
+
+The application repository must include:
+
+- `package.json`;
+- `yarn.lock`;
+- `.yarn/cache`.
+
+The install and cache buildpacks run only when `yarn.lock` and `.yarn/cache` are
+present. Repositories that do not commit `.yarn/cache` need a separate
+dependency installation step.
 
 For Yarn Plug'n'Play applications, the buildpack prepares launch-time Node
 options:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Buildpacks, builders and stack images for Node.js applications that use Yarn
 workspaces.
 
 The images are published in GitHub Container Registry. They are public and can
-be used with `pack`, CI jobs, or any tool that accepts Cloud Native Buildpacks
+be used with pack, CI jobs, or any tool that accepts Cloud Native Buildpacks
 builder and buildpack images.
 
 ## Build An Application
 
-These examples assume a zero-install Yarn workspace with `.yarn/cache`
-committed and a `start-image` script in `package.json`.
+These examples assume a zero-install Yarn workspace with .yarn/cache committed
+and a start-image script in package.json.
 
 Use Node 26 for new applications:
 
@@ -35,18 +35,18 @@ zero-install Yarn workspace application for build and launch.
 
 | Image | Use it for |
 | --- | --- |
-| `ghcr.io/atls/builder-base` | Building application images with the ATLS Node stack. |
-| `ghcr.io/atls/buildpack-yarn-workspace` | Building Yarn workspace applications. |
-| `ghcr.io/atls/stack-node` | Stack base, build and run images used by the builder. |
+| ghcr.io/atls/builder-base | Building application images with the ATLS Node stack. |
+| ghcr.io/atls/buildpack-yarn-workspace | Building Yarn workspace applications. |
+| ghcr.io/atls/stack-node | Stack base, build and run images used by the builder. |
 
-All release images are published for `linux/amd64` and `linux/arm64`.
+All release images are published for linux/amd64 and linux/arm64.
 
 ## Tags
 
 Use Node-line tags for normal application builds:
 
-- `ghcr.io/atls/builder-base:26`
-- `ghcr.io/atls/buildpack-yarn-workspace:26`
+- ghcr.io/atls/builder-base:26
+- ghcr.io/atls/buildpack-yarn-workspace:26
 
 Available Node lines:
 
@@ -59,45 +59,45 @@ for its Node version.
 
 Use semantic version tags when a rollout needs a fixed buildpack version:
 
-- `ghcr.io/atls/buildpack-yarn-workspace:0.2.2`
+- ghcr.io/atls/buildpack-yarn-workspace:0.2.2
 
 Stack images use role-specific tags:
 
-- `ghcr.io/atls/stack-node:base-26`
-- `ghcr.io/atls/stack-node:build-26`
-- `ghcr.io/atls/stack-node:run-26`
+- ghcr.io/atls/stack-node:base-26
+- ghcr.io/atls/stack-node:build-26
+- ghcr.io/atls/stack-node:run-26
 
 The same tags exist for Node 24. Tags without a Node suffix currently point to
 the default Node line, which is Node 26:
 
-- `ghcr.io/atls/stack-node:base`
-- `ghcr.io/atls/stack-node:build`
-- `ghcr.io/atls/stack-node:run`
+- ghcr.io/atls/stack-node:base
+- ghcr.io/atls/stack-node:build
+- ghcr.io/atls/stack-node:run
 
 For application configuration, prefer explicit Node-line tags such as
-`builder-base:26` and `buildpack-yarn-workspace:26`.
+builder-base:26 and buildpack-yarn-workspace:26.
 
 ## Yarn Workspace Buildpack
 
-`buildpack-yarn-workspace` is the application buildpack for zero-install Yarn
+buildpack-yarn-workspace is the application buildpack for zero-install Yarn
 workspace projects.
 
 The application repository must include:
 
-- `package.json`;
-- `yarn.lock`;
-- `.yarn/cache`;
-- a `start-image` script in `package.json`.
+- package.json;
+- yarn.lock;
+- .yarn/cache;
+- a start-image script in package.json.
 
-The install and cache buildpacks run only when `yarn.lock` and `.yarn/cache` are
-present. Repositories that do not commit `.yarn/cache` need a separate
-dependency installation step.
+The install and cache buildpacks run only when yarn.lock and .yarn/cache are
+present. Repositories that do not commit .yarn/cache need a separate dependency
+installation step.
 
 For Yarn Plug'n'Play applications, the buildpack prepares launch-time Node
 options:
 
-- loads `.pnp.cjs` with `--require`;
-- loads `.pnp.loader.mjs` with `--loader`;
+- loads .pnp.cjs with --require;
+- loads .pnp.loader.mjs with --loader;
 - enables source maps.
 
 Because the buildpack owns these launch options, the application launch script
@@ -111,13 +111,13 @@ can stay simple:
 }
 ```
 
-The image start buildpack runs `yarn start-image`. Do not duplicate Plug'n'Play
+The image start buildpack runs yarn start-image. Do not duplicate Plug'n'Play
 loader flags in that script unless the application intentionally overrides the
 buildpack behavior.
 
 ## Builder And Buildpack
 
-`builder-base` is a base builder. It does not make every application buildable by
+builder-base is a base builder. It does not make every application buildable by
 itself.
 
 For Yarn workspace applications, pass both images:
@@ -139,10 +139,10 @@ application buildpack image for the selected Node line.
 
 Component buildpacks and extensions are also published in GHCR:
 
-- `buildpack-yarn-install`
-- `buildpack-yarn-cache`
-- `buildpack-yarn-workspace-start`
-- `buildpack-require-extension`
-- `buildpack-extension-curl`
-- `buildpack-extension-htop`
-- `buildpack-extension-graphql-hive`
+- buildpack-yarn-install
+- buildpack-yarn-cache
+- buildpack-yarn-workspace-start
+- buildpack-require-extension
+- buildpack-extension-curl
+- buildpack-extension-htop
+- buildpack-extension-graphql-hive


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#98

## Как проверять
### До фикса
1. Контекст: README.md
Действие: открыть README репозитория
Ожидаемый результат: До фикса: README выглядит как внутренние заметки сопровождения релиза и описывает workflow, токены, release-please, Trivy и порядок обновления версий.

### После фикса
1. Контекст: README.md
Действие: открыть README репозитория
Ожидаемый результат: После фикса: README объясняет внешнему пользователю, как собрать приложение через GHCR-образы, какую линейку Node выбрать, какие теги доступны и что делает Yarn workspace buildpack.

## Пруфы
- README.md переписан как публичный usage-док
- `git diff --check`
- `rg -n 'release-please|Docker release|GitHub release|jam|ATLANTIS|Trivy|workflow|\.github|token|secret|Docker Hub|DOCKERHUB|managed|infra|release notes|internal' README.md`
