### PR TITLE
fix(release): disable setup-node yarn cache

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -341,7 +341,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ needs.validate-release.outputs.default_node_major }}
-          cache: yarn
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#104

## Как проверять
### До фикса
1. Контекст: GHCR image release после merge PR #103
Действие: открыть jobs Publish buildpack yarn-install, yarn-cache, yarn-workspace-start или require-extension
Ожидаемый результат: До фикса: шаг Setup Node.js вызывает yarn cache dir и падает до установки зависимостей

### После фикса
1. Контекст: GHCR image release после merge этого PR
Действие: открыть buildpack publish jobs
Ожидаемый результат: После фикса: Setup Node.js не запускает встроенный yarn cache, jobs доходят до Install dependencies и следующих publish steps

## Пруфы
- actionlint .github/workflows/docker-release.yaml
- git diff --check
- yarn install --immutable
- failed run: https://github.com/atls/buildpacks/actions/runs/28404793604
