### PR TITLE
chore(release): trigger GHCR image release

### DIFF
--- a/stacks/node/base/Dockerfile
+++ b/stacks/node/base/Dockerfile
@@ -8,6 +8,8 @@ ARG node_version=26
 ARG corepack_version=0.35.0
 ARG yarn_version=4.1.1
 
+# GHCR release validation.
+# Stack source changes intentionally trigger image publication.
 ENV COREPACK_HOME=/opt/corepack
 
 # Create user and group


### PR DESCRIPTION
## Таска
- Refs atls/buildpacks#104

## Как проверять
### До фикса
1. Контекст: GHCR image release после PR #103 и #105
Действие: открыть run https://github.com/atls/buildpacks/actions/runs/28404793604 и список post-merge runs после #105
Ожидаемый результат: До фикса: run после #103 падает на Setup Node.js, а #105 не создаёт новый GHCR image release run, потому что меняет только workflow YAML

### После фикса
1. Контекст: merge этого PR
Действие: открыть post-merge GHCR image release run на master
Ожидаемый результат: После фикса: workflow стартует от изменения stacks/node/base/Dockerfile и проверяет публикационный контур после #105

## Пруфы
- git diff --check
- docker buildx bake --file docker-bake.hcl --print stack --var IMAGE_PREFIX=ghcr.io/atls --var STACK_ID=tech.atls.stacks.node --var BASE_IMAGE=mcr.microsoft.com/devcontainers/base:debian-12 --var NODE_VERSION=26 --var RELEASE_TAG=26-trigger-smoke --var PLATFORMS=linux/amd64,linux/arm64
