### PR TITLE
ci(release): disable buildpack setup-node cache

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -341,7 +341,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ needs.validate-release.outputs.default_node_major }}
-          cache: yarn
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#102

## Как проверять
### До фикса
1. Контекст: GHCR image release, job Publish buildpack yarn-workspace-start, run https://github.com/atls/buildpacks/actions/runs/28529445370/job/84574846435
Действие: actions/setup-node@v6 запускается с cache: yarn
Ожидаемый результат: Setup Node.js падает на yarn cache dir под Yarn 1.3.17-atls

### После фикса
1. Контекст: GHCR image release, job Publish buildpack yarn-workspace-start
Действие: actions/setup-node@v6 запускается без cache: yarn, затем выполняется yarn install --immutable
Ожидаемый результат: Setup Node.js не вызывает yarn cache dir, job проходит к установке зависимостей

## Пруфы
- actionlint .github/workflows/docker-release.yaml
- git diff --check
- failed job: https://github.com/atls/buildpacks/actions/runs/28529445370/job/84574846435
