### PR TITLE
chore(release): trigger GHCR image release

### DIFF
--- a/stacks/node/base/Dockerfile
+++ b/stacks/node/base/Dockerfile
@@ -8,8 +8,8 @@ ARG node_version=26
 ARG corepack_version=0.35.0
 ARG yarn_version=4.1.1
 
-# GHCR release validation.
-# Stack source changes intentionally trigger image publication.
+# GHCR release trigger.
+# This stack source change validates the release workflow after workflow-only fixes.
 ENV COREPACK_HOME=/opt/corepack
 
 # Create user and group


### PR DESCRIPTION
## Таска
- Close atls/buildpacks#102

## Как проверять
### До фикса
1. Контекст: GHCR image release после merge PR #108, run https://github.com/atls/buildpacks/actions/runs/28529445370
Действие: publish buildpack jobs запускают actions/setup-node@v6 с cache: yarn
Ожидаемый результат: Setup Node.js падает на yarn cache dir под Yarn 1.3.17-atls

### После фикса
1. Контекст: GHCR image release после merge этого PR
Действие: изменение в stacks/node/base/Dockerfile запускает GHCR image release, а workflow уже не передаёт cache: yarn в publish buildpack jobs
Ожидаемый результат: Setup Node.js проходит без вызова yarn cache dir, release workflow доходит до публикации buildpack-компонентов

## Пруфы
- git diff --check
- actionlint .github/workflows/docker-release.yaml
- failed source run: https://github.com/atls/buildpacks/actions/runs/28529445370
- workflow cache fix: https://github.com/atls/buildpacks/pull/109
